### PR TITLE
[Feat] Spring Security 세팅

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,6 +30,13 @@ dependencies {
     // JPA
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
 
+    // security
+    implementation("org.springframework.boot:spring-boot-starter-security")
+
+    // oauth
+    implementation("org.springframework.boot:spring-boot-starter-oauth2-resource-server")
+    implementation("org.springframework.boot:spring-boot-starter-oauth2-client")
+
     // Mysql
     implementation("com.mysql:mysql-connector-j")
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,6 +20,7 @@ java {
 repositories {
     mavenCentral()
 }
+val jwtVersion = "0.12.6"
 
 dependencies {
     implementation("org.springframework.boot:spring-boot-starter-web")
@@ -37,6 +38,11 @@ dependencies {
 
     // Kotlin-Logging
     implementation("io.github.oshai:kotlin-logging-jvm:7.0.3")
+
+    // jwt
+    implementation("io.jsonwebtoken:jjwt-api:$jwtVersion")
+    implementation("io.jsonwebtoken:jjwt-impl:$jwtVersion")
+    implementation("io.jsonwebtoken:jjwt-jackson:$jwtVersion")
 
     // test
     testImplementation("org.springframework.boot:spring-boot-starter-test")

--- a/src/main/kotlin/com/yapp/demo/DemoApplication.kt
+++ b/src/main/kotlin/com/yapp/demo/DemoApplication.kt
@@ -1,9 +1,12 @@
 package com.yapp.demo
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.autoconfigure.security.servlet.UserDetailsServiceAutoConfiguration
 import org.springframework.boot.runApplication
 
-@SpringBootApplication
+@SpringBootApplication(
+    exclude = [UserDetailsServiceAutoConfiguration::class],
+)
 class DemoApplication
 
 fun main(args: Array<String>) {

--- a/src/main/kotlin/com/yapp/demo/auth/service/JwtTokenProvider.kt
+++ b/src/main/kotlin/com/yapp/demo/auth/service/JwtTokenProvider.kt
@@ -1,0 +1,86 @@
+package com.yapp.demo.auth.service
+
+import com.yapp.demo.common.config.properties.JwtProperties
+import com.yapp.demo.common.constants.TOKEN_TYPE_ACCESS
+import com.yapp.demo.common.constants.TOKEN_TYPE_REFRESH
+import com.yapp.demo.common.exception.CustomException
+import com.yapp.demo.common.exception.ErrorCode
+import io.jsonwebtoken.Claims
+import io.jsonwebtoken.ExpiredJwtException
+import io.jsonwebtoken.Jws
+import io.jsonwebtoken.JwtException
+import io.jsonwebtoken.Jwts
+import io.jsonwebtoken.io.Decoders
+import io.jsonwebtoken.security.Keys
+import org.springframework.stereotype.Component
+import java.util.Date
+
+@Component
+class JwtTokenProvider(
+    private val jwtProperties: JwtProperties,
+) {
+    private val decodedSecretKey = Keys.hmacShaKeyFor(Decoders.BASE64.decode(jwtProperties.secret))
+
+    fun generateAccessToken(userId: String): String {
+        return generateToken(
+            userId = userId,
+            type = TOKEN_TYPE_ACCESS,
+            expiryMillis = jwtProperties.accessTokenExpiryTime * 1000L,
+        )
+    }
+
+    fun generateRefreshToken(userId: String): String {
+        return generateToken(
+            userId = userId,
+            type = TOKEN_TYPE_REFRESH,
+            expiryMillis = jwtProperties.refreshTokenExpiryTime * 1000L,
+        )
+    }
+
+    fun extractUserId(
+        token: String,
+        tokenType: String,
+    ): Long {
+        val claims = getClaims(token)
+        val type = claims.payload[TOKEN_TYPE_KEY] as? String
+
+        if (type != tokenType) {
+            throw CustomException(ErrorCode.TOKEN_TYPE_MISMATCH)
+        }
+
+        return claims.payload.subject.toLong()
+    }
+
+    private fun generateToken(
+        userId: String,
+        type: String,
+        expiryMillis: Long,
+    ): String {
+        val now = Date()
+        val expirationDate = Date(now.time + expiryMillis)
+
+        return Jwts.builder()
+            .subject(userId)
+            .claim(TOKEN_TYPE_KEY, type)
+            .issuedAt(now)
+            .expiration(expirationDate)
+            .signWith(decodedSecretKey, Jwts.SIG.HS256)
+            .compact()
+    }
+
+    private fun getClaims(token: String): Jws<Claims> =
+        try {
+            Jwts.parser()
+                .verifyWith(decodedSecretKey)
+                .build()
+                .parseSignedClaims(token)
+        } catch (e: ExpiredJwtException) {
+            throw CustomException(ErrorCode.TOKEN_EXPIRED)
+        } catch (e: JwtException) {
+            throw CustomException(ErrorCode.TOKEN_INVALID)
+        }
+
+    companion object {
+        private const val TOKEN_TYPE_KEY = "token_type"
+    }
+}

--- a/src/main/kotlin/com/yapp/demo/common/config/JwtConfig.kt
+++ b/src/main/kotlin/com/yapp/demo/common/config/JwtConfig.kt
@@ -1,0 +1,9 @@
+package com.yapp.demo.common.config
+
+import com.yapp.demo.common.config.properties.JwtProperties
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+@EnableConfigurationProperties(JwtProperties::class)
+class JwtConfig

--- a/src/main/kotlin/com/yapp/demo/common/config/properties/JwtProperties.kt
+++ b/src/main/kotlin/com/yapp/demo/common/config/properties/JwtProperties.kt
@@ -1,0 +1,10 @@
+package com.yapp.demo.common.config.properties
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties(prefix = "jwt")
+data class JwtProperties(
+    val secret: String,
+    val accessTokenExpiryTime: Long,
+    val refreshTokenExpiryTime: Long,
+)

--- a/src/main/kotlin/com/yapp/demo/common/constants/GlobalConstants.kt
+++ b/src/main/kotlin/com/yapp/demo/common/constants/GlobalConstants.kt
@@ -1,0 +1,4 @@
+package com.yapp.demo.common.constants
+
+const val TOKEN_TYPE_ACCESS = "access"
+const val TOKEN_TYPE_REFRESH = "refresh"

--- a/src/main/kotlin/com/yapp/demo/common/exception/ErrorCode.kt
+++ b/src/main/kotlin/com/yapp/demo/common/exception/ErrorCode.kt
@@ -6,6 +6,8 @@ enum class ErrorCode(
     val message: String,
 ) {
     BAD_REQUEST(400, "C-400", "잘못된 요청입니다."),
+    UNAUTHORIZED(401, "C-401", "인증되지 않은 사용자입니다."),
+    FORBIDDEN(403, "C-403", "권한이 없습니다."),
     INTERNAL_SERVER_ERROR(500, "C-500", "예기치 못한 서버 오류가 발생했습니다."),
 
     // JWT

--- a/src/main/kotlin/com/yapp/demo/common/exception/ErrorCode.kt
+++ b/src/main/kotlin/com/yapp/demo/common/exception/ErrorCode.kt
@@ -7,4 +7,10 @@ enum class ErrorCode(
 ) {
     BAD_REQUEST(400, "C-400", "잘못된 요청입니다."),
     INTERNAL_SERVER_ERROR(500, "C-500", "예기치 못한 서버 오류가 발생했습니다."),
+
+    // JWT
+    TOKEN_EXPIRED(401, "T-001", "토큰이 만료되었습니다."),
+    TOKEN_INVALID(401, "T-002", "토큰이 유효하지 않습니다."),
+    TOKEN_NOT_FOUND(401, "T-003", "토큰을 찾을 수 없습니다."),
+    TOKEN_TYPE_MISMATCH(401, "T-004", "토큰의 타입이 올바르지 않습니다."),
 }

--- a/src/main/kotlin/com/yapp/demo/common/exception/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/com/yapp/demo/common/exception/GlobalExceptionHandler.kt
@@ -21,14 +21,14 @@ class GlobalExceptionHandler {
 
     @ExceptionHandler(IllegalArgumentException::class)
     fun handleIllegalArgumentException(e: IllegalArgumentException): ResponseEntity<ApiResponse<Unit>> {
-        logger.warn(e) { "code=${BAD_REQUEST.status}, message=${e.message}" }
+        logger.warn(e) { "code=${BAD_REQUEST.code}, message=${e.message}" }
         return ResponseEntity.status(BAD_REQUEST.status)
             .body(ApiResponse.error(BAD_REQUEST.status, BAD_REQUEST.message))
     }
 
     @ExceptionHandler(Exception::class)
     fun handleGlobalException(e: Exception): ResponseEntity<ApiResponse<Unit>> {
-        logger.error(e) { "code=${INTERNAL_SERVER_ERROR.status}, message=${e.message}" }
+        logger.error(e) { "code=${INTERNAL_SERVER_ERROR.code}, message=${e.message}" }
         return ResponseEntity.status(INTERNAL_SERVER_ERROR.status)
             .body(ApiResponse.error(INTERNAL_SERVER_ERROR.status, INTERNAL_SERVER_ERROR.message))
     }

--- a/src/main/kotlin/com/yapp/demo/common/filter/JwtAuthenticationFilter.kt
+++ b/src/main/kotlin/com/yapp/demo/common/filter/JwtAuthenticationFilter.kt
@@ -1,0 +1,55 @@
+package com.yapp.demo.common.filter
+
+import com.yapp.demo.auth.service.JwtTokenProvider
+import com.yapp.demo.common.constants.TOKEN_TYPE_ACCESS
+import com.yapp.demo.common.exception.CustomException
+import com.yapp.demo.common.exception.ErrorCode
+import io.github.oshai.kotlinlogging.KotlinLogging
+import jakarta.servlet.FilterChain
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.stereotype.Component
+import org.springframework.web.filter.OncePerRequestFilter
+
+private val log = KotlinLogging.logger {}
+
+@Component
+class JwtAuthenticationFilter(
+    private val jwtTokenProvider: JwtTokenProvider,
+) : OncePerRequestFilter() {
+    override fun doFilterInternal(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        filterChain: FilterChain,
+    ) {
+        try {
+            val accessToken = resolveToken(request)
+
+            val userId = jwtTokenProvider.extractUserId(accessToken, TOKEN_TYPE_ACCESS)
+
+            /***
+             * @TODO: UserPrincipal 설계 필요
+             * val authorities = listOf(SimpleGrantedAuthority("ROLE_USER")) //
+             * val authentication = UsernamePasswordAuthenticationToken(userId, null, authorities)
+             * SecurityContextHolder.getContext().authentication = authentication
+             */
+        } catch (e: Exception) {
+            log.warn(e) { "[JwtAuthenticationFilter.doFilterInternal] fail to parse token" }
+            throw e
+        }
+
+        filterChain.doFilter(request, response)
+    }
+
+    private fun resolveToken(request: HttpServletRequest): String {
+        val bearer = request.getHeader("Authorization")
+
+        return if (isValid(bearer)) {
+            bearer.substringAfter("Bearer ").trim()
+        } else {
+            throw CustomException(ErrorCode.TOKEN_NOT_FOUND)
+        }
+    }
+
+    private fun isValid(bearer: String?): Boolean = !bearer.isNullOrEmpty() && bearer.startsWith("Bearer ")
+}

--- a/src/main/kotlin/com/yapp/demo/common/security/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/yapp/demo/common/security/config/SecurityConfig.kt
@@ -1,0 +1,43 @@
+package com.yapp.demo.common.security.config
+
+import com.yapp.demo.common.security.exception.ForbiddenHandler
+import com.yapp.demo.common.security.exception.UnauthenticatedEntryPoint
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.security.config.annotation.web.builders.HttpSecurity
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
+import org.springframework.security.config.http.SessionCreationPolicy
+import org.springframework.security.web.SecurityFilterChain
+
+@Configuration
+@EnableWebSecurity
+class SecurityConfig(
+    private val unauthenticatedEntryPoint: UnauthenticatedEntryPoint,
+    private val forbiddenHandler: ForbiddenHandler,
+) {
+    @Bean
+    fun securityFilterChain(http: HttpSecurity): SecurityFilterChain {
+        http
+            .csrf { it.disable() }
+            .sessionManagement {
+                it.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+            }
+            .httpBasic { it.disable() }
+            .formLogin { it.disable() }
+            .logout { it.disable() }
+            .rememberMe { it.disable() }
+            .requestCache { it.disable() }
+            .authorizeHttpRequests {
+                it // TODO (회원가입 로그인 경로 수정)
+                    .requestMatchers("/health").permitAll()
+                    .anyRequest().authenticated()
+            }
+            .exceptionHandling {
+                it
+                    .authenticationEntryPoint(unauthenticatedEntryPoint)
+                    .accessDeniedHandler(forbiddenHandler)
+            }
+
+        return http.build()
+    }
+}

--- a/src/main/kotlin/com/yapp/demo/common/security/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/yapp/demo/common/security/config/SecurityConfig.kt
@@ -2,6 +2,8 @@ package com.yapp.demo.common.security.config
 
 import com.yapp.demo.common.security.exception.ForbiddenHandler
 import com.yapp.demo.common.security.exception.UnauthenticatedEntryPoint
+import com.yapp.demo.common.security.handler.OAuth2LoginFailureHandler
+import com.yapp.demo.common.security.handler.OAuth2LoginSuccessHandler
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
@@ -18,6 +20,8 @@ class SecurityConfig(
     private val unauthenticatedEntryPoint: UnauthenticatedEntryPoint,
     private val forbiddenHandler: ForbiddenHandler,
     private val customOAuth2UserService: OAuth2UserService<OAuth2UserRequest, OAuth2User>,
+    private val oAuth2LoginSuccessHandler: OAuth2LoginSuccessHandler,
+    private val oAuth2LoginFailureHandler: OAuth2LoginFailureHandler,
 ) {
     @Bean
     fun securityFilterChain(http: HttpSecurity): SecurityFilterChain {
@@ -49,8 +53,8 @@ class SecurityConfig(
             .oauth2Login {
                 it
                     .userInfoEndpoint { endpoint -> endpoint.userService(customOAuth2UserService) }
-                    .successHandler { _, _, _ -> run { println("success") } }
-                    .failureHandler { _, _, _ -> run { println("fail") } }
+                    .successHandler(oAuth2LoginSuccessHandler)
+                    .failureHandler(oAuth2LoginFailureHandler)
             }
 
         return http.build()

--- a/src/main/kotlin/com/yapp/demo/common/security/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/yapp/demo/common/security/config/SecurityConfig.kt
@@ -7,6 +7,9 @@ import org.springframework.context.annotation.Configuration
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
 import org.springframework.security.config.http.SessionCreationPolicy
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService
+import org.springframework.security.oauth2.core.user.OAuth2User
 import org.springframework.security.web.SecurityFilterChain
 
 @Configuration
@@ -14,6 +17,7 @@ import org.springframework.security.web.SecurityFilterChain
 class SecurityConfig(
     private val unauthenticatedEntryPoint: UnauthenticatedEntryPoint,
     private val forbiddenHandler: ForbiddenHandler,
+    private val customOAuth2UserService: OAuth2UserService<OAuth2UserRequest, OAuth2User>,
 ) {
     @Bean
     fun securityFilterChain(http: HttpSecurity): SecurityFilterChain {
@@ -28,14 +32,25 @@ class SecurityConfig(
             .rememberMe { it.disable() }
             .requestCache { it.disable() }
             .authorizeHttpRequests {
-                it // TODO (회원가입 로그인 경로 수정)
-                    .requestMatchers("/health").permitAll()
+                it
+                    .requestMatchers(
+                        "/oauth2/**",
+                        "/login/oauth2/**",
+                        "/health",
+                    )
+                    .permitAll()
                     .anyRequest().authenticated()
             }
             .exceptionHandling {
                 it
                     .authenticationEntryPoint(unauthenticatedEntryPoint)
                     .accessDeniedHandler(forbiddenHandler)
+            }
+            .oauth2Login {
+                it
+                    .userInfoEndpoint { endpoint -> endpoint.userService(customOAuth2UserService) }
+                    .successHandler { _, _, _ -> run { println("success") } }
+                    .failureHandler { _, _, _ -> run { println("fail") } }
             }
 
         return http.build()

--- a/src/main/kotlin/com/yapp/demo/common/security/exception/ForbiddenHandler.kt
+++ b/src/main/kotlin/com/yapp/demo/common/security/exception/ForbiddenHandler.kt
@@ -1,0 +1,33 @@
+package com.yapp.demo.common.security.exception
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.yapp.demo.common.dto.ApiResponse
+import com.yapp.demo.common.exception.ErrorCode.FORBIDDEN
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.http.MediaType
+import org.springframework.security.access.AccessDeniedException
+import org.springframework.security.web.access.AccessDeniedHandler
+import org.springframework.stereotype.Component
+
+@Component
+class ForbiddenHandler(
+    private val objectMapper: ObjectMapper,
+) : AccessDeniedHandler {
+    override fun handle(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        accessDeniedException: AccessDeniedException,
+    ) {
+        val apiResponse = ApiResponse.error(FORBIDDEN.status, FORBIDDEN.message)
+        val responseBody = objectMapper.writeValueAsString(apiResponse)
+
+        response.apply {
+            contentType = MediaType.APPLICATION_JSON_VALUE
+            status = apiResponse.code
+            characterEncoding = "UTF-8"
+            writer.write(responseBody)
+            writer.flush()
+        }
+    }
+}

--- a/src/main/kotlin/com/yapp/demo/common/security/exception/UnauthenticatedEntryPoint.kt
+++ b/src/main/kotlin/com/yapp/demo/common/security/exception/UnauthenticatedEntryPoint.kt
@@ -9,6 +9,7 @@ import org.springframework.http.MediaType
 import org.springframework.security.core.AuthenticationException
 import org.springframework.security.web.AuthenticationEntryPoint
 import org.springframework.stereotype.Component
+import java.nio.charset.StandardCharsets
 
 @Component
 class UnauthenticatedEntryPoint(
@@ -25,7 +26,7 @@ class UnauthenticatedEntryPoint(
         response.apply {
             contentType = MediaType.APPLICATION_JSON_VALUE
             status = apiResponse.code
-            characterEncoding = "UTF-8"
+            characterEncoding = StandardCharsets.UTF_8.name()
             writer.write(responseBody)
             writer.flush()
         }

--- a/src/main/kotlin/com/yapp/demo/common/security/exception/UnauthenticatedEntryPoint.kt
+++ b/src/main/kotlin/com/yapp/demo/common/security/exception/UnauthenticatedEntryPoint.kt
@@ -1,0 +1,33 @@
+package com.yapp.demo.common.security.exception
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.yapp.demo.common.dto.ApiResponse
+import com.yapp.demo.common.exception.ErrorCode.UNAUTHORIZED
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.http.MediaType
+import org.springframework.security.core.AuthenticationException
+import org.springframework.security.web.AuthenticationEntryPoint
+import org.springframework.stereotype.Component
+
+@Component
+class UnauthenticatedEntryPoint(
+    private val objectMapper: ObjectMapper,
+) : AuthenticationEntryPoint {
+    override fun commence(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        authException: AuthenticationException,
+    ) {
+        val apiResponse = ApiResponse.error(UNAUTHORIZED.status, UNAUTHORIZED.message)
+        val responseBody = objectMapper.writeValueAsString(apiResponse)
+
+        response.apply {
+            contentType = MediaType.APPLICATION_JSON_VALUE
+            status = apiResponse.code
+            characterEncoding = "UTF-8"
+            writer.write(responseBody)
+            writer.flush()
+        }
+    }
+}

--- a/src/main/kotlin/com/yapp/demo/common/security/handler/OAuth2LoginFailureHandler.kt
+++ b/src/main/kotlin/com/yapp/demo/common/security/handler/OAuth2LoginFailureHandler.kt
@@ -1,26 +1,28 @@
-package com.yapp.demo.common.security.exception
+package com.yapp.demo.common.security.handler
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.yapp.demo.common.dto.ApiResponse
-import com.yapp.demo.common.exception.ErrorCode.FORBIDDEN
+import com.yapp.demo.common.exception.ErrorCode.UNAUTHORIZED
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
 import org.springframework.http.MediaType
-import org.springframework.security.access.AccessDeniedException
-import org.springframework.security.web.access.AccessDeniedHandler
+import org.springframework.security.core.AuthenticationException
+import org.springframework.security.web.authentication.AuthenticationFailureHandler
 import org.springframework.stereotype.Component
 import java.nio.charset.StandardCharsets
 
 @Component
-class ForbiddenHandler(
+class OAuth2LoginFailureHandler(
     private val objectMapper: ObjectMapper,
-) : AccessDeniedHandler {
-    override fun handle(
-        request: HttpServletRequest,
-        response: HttpServletResponse,
-        accessDeniedException: AccessDeniedException,
+) : AuthenticationFailureHandler {
+    override fun onAuthenticationFailure(
+        request: HttpServletRequest?,
+        response: HttpServletResponse?,
+        exception: AuthenticationException?,
     ) {
-        val apiResponse = ApiResponse.error(FORBIDDEN.status, FORBIDDEN.message)
+        requireNotNull(response) { "response is null" }
+
+        val apiResponse = ApiResponse.error(UNAUTHORIZED.status, UNAUTHORIZED.message)
         val responseBody = objectMapper.writeValueAsString(apiResponse)
 
         response.apply {

--- a/src/main/kotlin/com/yapp/demo/common/security/handler/OAuth2LoginSuccessHandler.kt
+++ b/src/main/kotlin/com/yapp/demo/common/security/handler/OAuth2LoginSuccessHandler.kt
@@ -1,5 +1,7 @@
 package com.yapp.demo.common.security.handler
 
+import com.yapp.demo.common.exception.CustomException
+import com.yapp.demo.common.exception.ErrorCode.UNAUTHORIZED
 import com.yapp.demo.common.security.oauth2.userinfo.OAuth2UserInfo
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
@@ -15,9 +17,11 @@ class OAuth2LoginSuccessHandler : AuthenticationSuccessHandler {
         authentication: Authentication?,
     ) {
         requireNotNull(response) { "response is null" }
-        requireNotNull(authentication) { "Invalid is null" }
+        requireNotNull(authentication) { "authentication is null" }
 
-        val authUser = authentication.principal as OAuth2UserInfo
+        val authUser =
+            authentication.principal as? OAuth2UserInfo
+                ?: throw CustomException(UNAUTHORIZED)
 
         // TODO(jwt 발급 및 반환)
     }

--- a/src/main/kotlin/com/yapp/demo/common/security/handler/OAuth2LoginSuccessHandler.kt
+++ b/src/main/kotlin/com/yapp/demo/common/security/handler/OAuth2LoginSuccessHandler.kt
@@ -1,0 +1,24 @@
+package com.yapp.demo.common.security.handler
+
+import com.yapp.demo.common.security.oauth2.userinfo.OAuth2UserInfo
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.security.core.Authentication
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler
+import org.springframework.stereotype.Component
+
+@Component
+class OAuth2LoginSuccessHandler : AuthenticationSuccessHandler {
+    override fun onAuthenticationSuccess(
+        request: HttpServletRequest?,
+        response: HttpServletResponse?,
+        authentication: Authentication?,
+    ) {
+        requireNotNull(response) { "response is null" }
+        requireNotNull(authentication) { "Invalid is null" }
+
+        val authUser = authentication.principal as OAuth2UserInfo
+
+        // TODO(jwt 발급 및 반환)
+    }
+}

--- a/src/main/kotlin/com/yapp/demo/common/security/oauth2/service/CustomOAuth2UserService.kt
+++ b/src/main/kotlin/com/yapp/demo/common/security/oauth2/service/CustomOAuth2UserService.kt
@@ -1,0 +1,23 @@
+package com.yapp.demo.common.security.oauth2.service
+
+import com.yapp.demo.common.security.oauth2.userinfo.SocialProvider
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService
+import org.springframework.security.oauth2.core.user.OAuth2User
+import org.springframework.stereotype.Service
+
+@Service
+class CustomOAuth2UserService(
+    private val defaultOAuth2UserService: DefaultOAuth2UserService = DefaultOAuth2UserService(),
+) : OAuth2UserService<OAuth2UserRequest, OAuth2User> {
+    override fun loadUser(request: OAuth2UserRequest): OAuth2User {
+        val oauthUser = defaultOAuth2UserService.loadUser(request)
+
+        SocialProvider.from(request.clientRegistration.registrationId)
+            .createUserInfo(oauthUser.attributes)
+
+        // TODO(user save || get)
+        return oauthUser
+    }
+}

--- a/src/main/kotlin/com/yapp/demo/common/security/oauth2/service/CustomOAuth2UserService.kt
+++ b/src/main/kotlin/com/yapp/demo/common/security/oauth2/service/CustomOAuth2UserService.kt
@@ -11,13 +11,14 @@ import org.springframework.stereotype.Service
 class CustomOAuth2UserService(
     private val defaultOAuth2UserService: DefaultOAuth2UserService = DefaultOAuth2UserService(),
 ) : OAuth2UserService<OAuth2UserRequest, OAuth2User> {
-    override fun loadUser(request: OAuth2UserRequest): OAuth2User {
+    override fun loadUser(request: OAuth2UserRequest?): OAuth2User {
+        requireNotNull(request) { "OAuth2 request is null" }
+
         val oauthUser = defaultOAuth2UserService.loadUser(request)
 
-        SocialProvider.from(request.clientRegistration.registrationId)
+        return SocialProvider.from(request.clientRegistration.registrationId)
             .createUserInfo(oauthUser.attributes)
 
         // TODO(user save || get)
-        return oauthUser
     }
 }

--- a/src/main/kotlin/com/yapp/demo/common/security/oauth2/userinfo/AppleUserInfo.kt
+++ b/src/main/kotlin/com/yapp/demo/common/security/oauth2/userinfo/AppleUserInfo.kt
@@ -2,14 +2,14 @@ package com.yapp.demo.common.security.oauth2.userinfo
 
 import org.springframework.security.core.authority.SimpleGrantedAuthority
 
-class AppleUserInfo(
+data class AppleUserInfo(
     private val attributes: Map<String, Any>,
 ) : OAuth2UserInfo {
     private val attrs = attributes
     override val id: String = attrs["response"] as String
     override val email: String = attrs["email"] as String
 
-    override fun getName(): String = attrs["name"] as String
+    override fun getName(): String = (attrs["name"] as? String) ?: ""
 
     override fun getAttributes(): Map<String, Any> = attributes
 

--- a/src/main/kotlin/com/yapp/demo/common/security/oauth2/userinfo/AppleUserInfo.kt
+++ b/src/main/kotlin/com/yapp/demo/common/security/oauth2/userinfo/AppleUserInfo.kt
@@ -1,0 +1,21 @@
+package com.yapp.demo.common.security.oauth2.userinfo
+
+class AppleUserInfo(
+    attributes: Map<String, Any>,
+) : OAuth2UserInfo {
+    private val attrs = attributes
+    override val id: String
+        get() {
+            return attrs["response"] as String
+        }
+
+    override val name: String
+        get() {
+            return attrs["name"] as String
+        }
+
+    override val email: String
+        get() {
+            return attrs["email"] as String
+        }
+}

--- a/src/main/kotlin/com/yapp/demo/common/security/oauth2/userinfo/AppleUserInfo.kt
+++ b/src/main/kotlin/com/yapp/demo/common/security/oauth2/userinfo/AppleUserInfo.kt
@@ -1,21 +1,17 @@
 package com.yapp.demo.common.security.oauth2.userinfo
 
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+
 class AppleUserInfo(
-    attributes: Map<String, Any>,
+    private val attributes: Map<String, Any>,
 ) : OAuth2UserInfo {
     private val attrs = attributes
-    override val id: String
-        get() {
-            return attrs["response"] as String
-        }
+    override val id: String = attrs["response"] as String
+    override val email: String = attrs["email"] as String
 
-    override val name: String
-        get() {
-            return attrs["name"] as String
-        }
+    override fun getName(): String = attrs["name"] as String
 
-    override val email: String
-        get() {
-            return attrs["email"] as String
-        }
+    override fun getAttributes(): Map<String, Any> = attributes
+
+    override fun getAuthorities(): List<SimpleGrantedAuthority> = listOf(SimpleGrantedAuthority("ROLE_USER"))
 }

--- a/src/main/kotlin/com/yapp/demo/common/security/oauth2/userinfo/KakaoUserInfo.kt
+++ b/src/main/kotlin/com/yapp/demo/common/security/oauth2/userinfo/KakaoUserInfo.kt
@@ -2,7 +2,7 @@ package com.yapp.demo.common.security.oauth2.userinfo
 
 import org.springframework.security.core.authority.SimpleGrantedAuthority
 
-class KakaoUserInfo(
+data class KakaoUserInfo(
     private val attributes: Map<String, Any>,
 ) : OAuth2UserInfo {
     private val account: Map<String, Any> =

--- a/src/main/kotlin/com/yapp/demo/common/security/oauth2/userinfo/KakaoUserInfo.kt
+++ b/src/main/kotlin/com/yapp/demo/common/security/oauth2/userinfo/KakaoUserInfo.kt
@@ -1,0 +1,24 @@
+package com.yapp.demo.common.security.oauth2.userinfo
+
+class KakaoUserInfo(
+    attributes: Map<String, Any>,
+) : OAuth2UserInfo {
+    private val account: Map<String, Any> =
+        (attributes["kakao_account"] as? Map<String, Any>)
+            ?: throw IllegalArgumentException("Kakao account data is missing")
+
+    override val id: String
+        get() {
+            return account["response"] as String
+        }
+
+    override val name: String
+        get() {
+            val profile = account["profile"] as Map<String, Any>
+            return profile["nickname"] as String
+        }
+    override val email: String
+        get() {
+            return account["email"] as String
+        }
+}

--- a/src/main/kotlin/com/yapp/demo/common/security/oauth2/userinfo/KakaoUserInfo.kt
+++ b/src/main/kotlin/com/yapp/demo/common/security/oauth2/userinfo/KakaoUserInfo.kt
@@ -1,24 +1,23 @@
 package com.yapp.demo.common.security.oauth2.userinfo
 
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+
 class KakaoUserInfo(
-    attributes: Map<String, Any>,
+    private val attributes: Map<String, Any>,
 ) : OAuth2UserInfo {
     private val account: Map<String, Any> =
         (attributes["kakao_account"] as? Map<String, Any>)
             ?: throw IllegalArgumentException("Kakao account data is missing")
 
-    override val id: String
-        get() {
-            return account["response"] as String
-        }
+    override val id: String = account["response"] as String
+    override val email: String = account["email"] as String
 
-    override val name: String
-        get() {
-            val profile = account["profile"] as Map<String, Any>
-            return profile["nickname"] as String
-        }
-    override val email: String
-        get() {
-            return account["email"] as String
-        }
+    override fun getName(): String {
+        val profile = account["profile"] as Map<String, Any>
+        return profile["nickname"] as String
+    }
+
+    override fun getAttributes(): Map<String, Any> = attributes
+
+    override fun getAuthorities(): List<SimpleGrantedAuthority> = listOf(SimpleGrantedAuthority("ROLE_USER"))
 }

--- a/src/main/kotlin/com/yapp/demo/common/security/oauth2/userinfo/OAuth2UserInfo.kt
+++ b/src/main/kotlin/com/yapp/demo/common/security/oauth2/userinfo/OAuth2UserInfo.kt
@@ -1,7 +1,8 @@
 package com.yapp.demo.common.security.oauth2.userinfo
 
-interface OAuth2UserInfo {
+import org.springframework.security.oauth2.core.user.OAuth2User
+
+interface OAuth2UserInfo : OAuth2User {
     val id: String
     val email: String
-    val name: String
 }

--- a/src/main/kotlin/com/yapp/demo/common/security/oauth2/userinfo/OAuth2UserInfo.kt
+++ b/src/main/kotlin/com/yapp/demo/common/security/oauth2/userinfo/OAuth2UserInfo.kt
@@ -1,0 +1,7 @@
+package com.yapp.demo.common.security.oauth2.userinfo
+
+interface OAuth2UserInfo {
+    val id: String
+    val email: String
+    val name: String
+}

--- a/src/main/kotlin/com/yapp/demo/common/security/oauth2/userinfo/SocialProvider.kt
+++ b/src/main/kotlin/com/yapp/demo/common/security/oauth2/userinfo/SocialProvider.kt
@@ -1,0 +1,18 @@
+package com.yapp.demo.common.security.oauth2.userinfo
+
+enum class SocialProvider(
+    private val id: String,
+    private val creator: (Map<String, Any>) -> OAuth2UserInfo,
+) {
+    KAKAO("kakao", ::KakaoUserInfo),
+    APPLE("apple", ::AppleUserInfo),
+    ;
+
+    fun createUserInfo(attributes: Map<String, Any>): OAuth2UserInfo = creator(attributes)
+
+    companion object {
+        fun from(registrationId: String) =
+            entries.find { it.id == registrationId }
+                ?: throw IllegalArgumentException("Unknown provider: $registrationId")
+    }
+}

--- a/src/main/kotlin/com/yapp/demo/common/security/oauth2/userinfo/SocialProvider.kt
+++ b/src/main/kotlin/com/yapp/demo/common/security/oauth2/userinfo/SocialProvider.kt
@@ -4,18 +4,18 @@ import com.yapp.demo.common.exception.CustomException
 import com.yapp.demo.common.exception.ErrorCode.BAD_REQUEST
 
 enum class SocialProvider(
-    private val id: String,
     private val creator: (Map<String, Any>) -> OAuth2UserInfo,
 ) {
-    KAKAO("kakao", ::KakaoUserInfo),
-    APPLE("apple", ::AppleUserInfo),
+    KAKAO(::KakaoUserInfo),
+    APPLE(::AppleUserInfo),
+    GOOGLE(::GoogleUserInfo),
     ;
 
     fun createUserInfo(attributes: Map<String, Any>): OAuth2UserInfo = creator(attributes)
 
     companion object {
         fun from(registrationId: String) =
-            entries.find { it.id == registrationId }
+            entries.find { it.name.lowercase() == registrationId }
                 ?: throw CustomException(BAD_REQUEST)
     }
 }

--- a/src/main/kotlin/com/yapp/demo/common/security/oauth2/userinfo/SocialProvider.kt
+++ b/src/main/kotlin/com/yapp/demo/common/security/oauth2/userinfo/SocialProvider.kt
@@ -1,5 +1,8 @@
 package com.yapp.demo.common.security.oauth2.userinfo
 
+import com.yapp.demo.common.exception.CustomException
+import com.yapp.demo.common.exception.ErrorCode.BAD_REQUEST
+
 enum class SocialProvider(
     private val id: String,
     private val creator: (Map<String, Any>) -> OAuth2UserInfo,
@@ -13,6 +16,6 @@ enum class SocialProvider(
     companion object {
         fun from(registrationId: String) =
             entries.find { it.id == registrationId }
-                ?: throw IllegalArgumentException("Unknown provider: $registrationId")
+                ?: throw CustomException(BAD_REQUEST)
     }
 }

--- a/src/main/kotlin/com/yapp/demo/common/security/oauth2/userinfo/SocialProvider.kt
+++ b/src/main/kotlin/com/yapp/demo/common/security/oauth2/userinfo/SocialProvider.kt
@@ -8,7 +8,6 @@ enum class SocialProvider(
 ) {
     KAKAO(::KakaoUserInfo),
     APPLE(::AppleUserInfo),
-    GOOGLE(::GoogleUserInfo),
     ;
 
     fun createUserInfo(attributes: Map<String, Any>): OAuth2UserInfo = creator(attributes)

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -12,3 +12,8 @@ spring:
     show-sql: false
     hibernate:
       ddl-auto: none
+
+jwt:
+  secret: ${JWT_SECRET}
+  access-token-expiry-time: ${JWT_ACCESS_TOKEN_EXPIRY_TIME}
+  refresh-token-expiry-time: ${JWT_REFRESH_TOKEN_EXPIRY_TIME}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,33 @@
 spring:
   profiles:
     active: local
+
+  security:
+    oauth2:
+      client:
+        registration:
+          apple:
+            clientId: ${APPLE_CLIENT_ID}
+            clientSecret: ${APPLE_CLIENT_SECRET}
+            authorization-grant-type: authorization_code
+            redirect-uri: http://localhost:8080/login/oauth2/code/apple
+            client-authentication-method: POST
+            client-name: apple
+            scope: name, email
+          kakao:
+            clientId: ${KAKAO_CLIENT_ID}
+            clientSecret: ${KAKAO_CLIENT_SECRET}
+            authorization-grant-type: authorization_code
+            redirect-uri: http://localhost:8080/login/oauth2/code/kakao
+            client-authentication-method: client_secret_post
+            client-name: kakao
+            scope: profile_nickname, account_email
+        provider:
+          apple:
+            authorizationUri: https://appleid.apple.com/auth/authorize?response_mode=form_post
+            tokenUri: https://appleid.apple.com/auth/token
+          kakao:
+            authorizationUri: https://kauth.kakao.com/oauth/authorize
+            tokenUri: https://kauth.kakao.com/oauth/token
+            userInfoUri: https://kapi.kakao.com/v2/user/me
+            userNameAttribute: id

--- a/src/test/kotlin/com/yapp/demo/auth/service/JwtTokenProviderTest.kt
+++ b/src/test/kotlin/com/yapp/demo/auth/service/JwtTokenProviderTest.kt
@@ -1,0 +1,77 @@
+package com.yapp.demo.auth.service
+
+import com.yapp.demo.common.config.properties.JwtProperties
+import com.yapp.demo.common.constants.TOKEN_TYPE_ACCESS
+import com.yapp.demo.common.constants.TOKEN_TYPE_REFRESH
+import com.yapp.demo.common.exception.CustomException
+import com.yapp.demo.common.exception.ErrorCode
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.junit.jupiter.MockitoExtension
+import kotlin.test.Test
+
+@ExtendWith(MockitoExtension::class)
+class JwtTokenProviderTest {
+    private val secretKey = "mysecretkey123456789012345678901234mysecretkey123456789012345678901234"
+    private val jwtProperties =
+        JwtProperties(
+            secret = secretKey,
+            accessTokenExpiryTime = 3600,
+            refreshTokenExpiryTime = 604800,
+        )
+
+    private lateinit var jwtTokenProvider: JwtTokenProvider
+
+    @BeforeEach
+    fun setUp() {
+        jwtTokenProvider = JwtTokenProvider(jwtProperties)
+    }
+
+    @Test
+    fun `AccessToken과 RefreshToken 생성 후 userId 추출이 동일해야 한다`() {
+        val userId = "12345"
+
+        val accessToken = jwtTokenProvider.generateAccessToken(userId)
+        val refreshToken = jwtTokenProvider.generateRefreshToken(userId)
+
+        val extractedUserIdFromAccess = jwtTokenProvider.extractUserId(accessToken, TOKEN_TYPE_ACCESS)
+        val extractedUserIdFromRefresh = jwtTokenProvider.extractUserId(refreshToken, TOKEN_TYPE_REFRESH)
+
+        assertEquals(userId.toLong(), extractedUserIdFromAccess)
+        assertEquals(userId.toLong(), extractedUserIdFromRefresh)
+    }
+
+    @Test
+    fun `잘못된 토큰을 넣으면 TOKEN_INVALID 예외가 발생해야 한다`() {
+        val invalidToken = "this.is.not.a.valid.token"
+
+        val exception =
+            assertThrows<CustomException> {
+                jwtTokenProvider.extractUserId(invalidToken, TOKEN_TYPE_ACCESS)
+            }
+
+        assertEquals(ErrorCode.TOKEN_INVALID, exception.errorCode)
+    }
+
+    @Test
+    fun `만료된 토큰을 넣으면 TOKEN_EXPIRED 예외가 발생해야 한다`() {
+        val expiredJwtProperties =
+            JwtProperties(
+                secret = secretKey,
+                accessTokenExpiryTime = -1,
+                refreshTokenExpiryTime = -1,
+            )
+
+        val expiredTokenProvider = JwtTokenProvider(expiredJwtProperties)
+        val token = expiredTokenProvider.generateAccessToken("1")
+
+        val exception =
+            assertThrows<CustomException> {
+                expiredTokenProvider.extractUserId(token, TOKEN_TYPE_ACCESS)
+            }
+
+        assertEquals(ErrorCode.TOKEN_EXPIRED, exception.errorCode)
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -11,7 +11,38 @@ spring:
     hibernate:
       ddl-auto: create
 
+  security:
+    oauth2:
+      client:
+        registration:
+          apple:
+            clientId: secret
+            clientSecret: secret
+            authorization-grant-type: authorization_code
+            redirect-uri: http://localhost:8080/login/oauth2/code/apple
+            client-authentication-method: POST
+            client-name: apple
+            scope: name, email
+          kakao:
+            clientId: secret
+            clientSecret: secret
+            authorization-grant-type: authorization_code
+            redirect-uri: http://localhost:8080/login/oauth2/code/kakao
+            client-authentication-method: client_secret_post
+            client-name: kakao
+            scope: profile_nickname, account_email
+        provider:
+          apple:
+            authorizationUri: https://appleid.apple.com/auth/authorize?response_mode=form_post
+            tokenUri: https://appleid.apple.com/auth/token
+          kakao:
+            authorizationUri: https://kauth.kakao.com/oauth/authorize
+            tokenUri: https://kauth.kakao.com/oauth/token
+            userInfoUri: https://kapi.kakao.com/v2/user/me
+            userNameAttribute: id
+
 jwt:
   secret: abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789
   access-token-expiry-time: 1800
   refresh-token-expiry-time: 1209600
+

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -10,3 +10,8 @@ spring:
   jpa:
     hibernate:
       ddl-auto: create
+
+jwt:
+  secret: abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789
+  access-token-expiry-time: 1800
+  refresh-token-expiry-time: 1209600


### PR DESCRIPTION
## 🔍 반영 내용
- 인증, 인가 실패 시 예외 처리
- Kakao, Apple UserInfo

## ✅ 체크리스트
- [x] 코드 컨벤션을 지켰나요?
- [ ] 테스트 케이스를 작성했나요?
- [x] 빌드가 정상적으로 됐나요?
- [x] 본인(작성자)를 assign 했나요?

## 🔗 관련 이슈
<!-- ex. Close #123 -->
Close #3 

## 👀 리뷰어에게 바라는 점
- 코드래빗에게 리뷰 받아보고 싶어서 먼저 올립니다~
- 좀 더 수정하고 리뷰 요청드릴게요 ㅎㅎ
- 이번에 공부하면서 OIDC에 대해 알게 됐는데, OAuth2만 해도 될지, OIDC를 사용할지 고민중입니다. 의견 있으심 알려주세요ㅎ-ㅎ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 카카오와 애플 소셜 로그인을 위한 OAuth2 인증 기능이 추가되었습니다.
  - 인증 및 인가 실패 시 표준화된 JSON 에러 응답을 제공합니다.
  - 인증 성공 및 실패, 권한 거부 상황에 대한 커스텀 핸들러가 도입되었습니다.
  - OAuth2 사용자 정보 처리 및 소셜 로그인 공급자별 사용자 정보 매핑이 구현되었습니다.

- **설정**
  - 카카오 및 애플 OAuth2 클라이언트 설정이 추가되었습니다.
  - 보안 관련 설정이 강화되어 세션 관리가 무상태로 변경되고, 특정 엔드포인트에 대한 접근 권한이 설정되었습니다.

- **버그 수정**
  - 인증되지 않은 사용자 및 권한이 없는 사용자에 대한 에러 코드가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->