### PR TITLE
[Feat] Request 로깅 필터 추가

### DIFF
--- a/src/main/kotlin/com/yapp/demo/common/logging/CustomRequestLoggingFilter.kt
+++ b/src/main/kotlin/com/yapp/demo/common/logging/CustomRequestLoggingFilter.kt
@@ -1,0 +1,42 @@
+package com.yapp.demo.common.logging
+
+import jakarta.servlet.http.HttpServletRequest
+import org.springframework.stereotype.Component
+import org.springframework.web.filter.CommonsRequestLoggingFilter
+
+@Component
+class CustomRequestLoggingFilter : CommonsRequestLoggingFilter() {
+    init {
+        isIncludeQueryString = true
+        isIncludePayload = true
+        maxPayloadLength = 10_000
+        this.setAfterMessagePrefix("[request = ")
+    }
+
+    override fun shouldLog(request: HttpServletRequest): Boolean {
+        val uri = request.requestURI
+        return EXCLUDED_URI_PREFIXES.none { uri.startsWith(it) }
+    }
+
+    override fun beforeRequest(
+        request: HttpServletRequest,
+        message: String,
+    ) {
+    }
+
+    override fun afterRequest(
+        request: HttpServletRequest,
+        message: String,
+    ) {
+        logger.info(message)
+    }
+
+    companion object {
+        private val EXCLUDED_URI_PREFIXES =
+            setOf(
+                "/health",
+                "/v1/swagger-ui",
+                "/static/swagger",
+            )
+    }
+}

--- a/src/main/kotlin/com/yapp/demo/common/security/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/yapp/demo/common/security/config/SecurityConfig.kt
@@ -10,6 +10,7 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.http.SessionCreationPolicy
 import org.springframework.security.web.SecurityFilterChain
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter
+import org.springframework.web.filter.CommonsRequestLoggingFilter
 
 @Configuration
 @EnableWebSecurity
@@ -17,6 +18,7 @@ class SecurityConfig(
     private val unauthenticatedEntryPoint: UnauthenticatedEntryPoint,
     private val forbiddenHandler: ForbiddenHandler,
     private val jwtAuthenticationFilter: JwtAuthenticationFilter,
+    private val requestLoggingFilter: CommonsRequestLoggingFilter,
 ) {
     @Bean
     fun securityFilterChain(http: HttpSecurity): SecurityFilterChain {
@@ -39,6 +41,7 @@ class SecurityConfig(
                 it.authenticationEntryPoint(unauthenticatedEntryPoint)
                     .accessDeniedHandler(forbiddenHandler)
             }
+            .addFilterBefore(requestLoggingFilter, UsernamePasswordAuthenticationFilter::class.java)
             .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter::class.java)
 
         return http.build()


### PR DESCRIPTION
## 🔍 반영 내용
Request 로깅 작업 했습니다

요청에 대해 아래 형식으로 로깅됩니다.
```
2025-06-21T22:44:12.831+09:00  INFO 79308 --- [yapp] [io-8080-exec-10] c.y.d.c.l.CustomRequestLoggingFilter     : [request = POST /v1/auth/login, payload={
  "provider": "KAKAO",
  "authorizationCode": "authorization-code"
}]
```

## ✅ 체크리스트
- [x] 코드 컨벤션을 지켰나요?
- [ ] 테스트 케이스를 작성했나요?
- [x] 빌드가 정상적으로 됐나요?
- [x] 본인(작성자)를 assign 했나요?

## 🔗 관련 이슈
<!-- ex. Close #123 -->
Close #13 

## 👀 리뷰어에게 바라는 점
<!-- 코드에서 중점적으로 봐줬으면 하는 부분이나, 궁금한 부분을 자유롭게 작성해주세요 -->
- 제외해야 하는 URI 더 있다면 말씀해주세요!
- authorization-code는 로깅해도 괜찮겠죠 ,,?
