### PR TITLE
[Feat] Jwt 필터 빈 제거

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN ./gradlew --no-daemon dependencies
 # 소스코드 복사 및 애플리케이션 빌드
 # Layered Jar 활성화를 위해 bootJar 태스크를 사용
 COPY . .
-RUN ./gradlew bootJar -x test
+RUN ./gradlew copyToSwagger bootJar -x test
 
 # Layer Tools를 사용하여 Jar 파일에서 계층 분리
 WORKDIR /app/build/libs

--- a/scripts/dev-deploy.sh
+++ b/scripts/dev-deploy.sh
@@ -5,7 +5,7 @@
 # ===============================
 NGINX_CONF_DIR="./nginx"
 MAX_RETRIES=50
-HEALTHCHECK_WAIT=3
+HEALTHCHECK_WAIT=10
 
 # ===============================
 # 함수: 헬스 체크

--- a/src/main/kotlin/com/yapp/demo/common/filter/JwtAuthenticationFilter.kt
+++ b/src/main/kotlin/com/yapp/demo/common/filter/JwtAuthenticationFilter.kt
@@ -10,12 +10,10 @@ import jakarta.servlet.FilterChain
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
 import org.springframework.security.core.context.SecurityContextHolder
-import org.springframework.stereotype.Component
 import org.springframework.web.filter.OncePerRequestFilter
 
 private val log = KotlinLogging.logger {}
 
-@Component
 class JwtAuthenticationFilter(
     private val jwtTokenProvider: JwtTokenProvider,
     private val blackListRepository: RedisBlackListRepository,


### PR DESCRIPTION
## 🔍 반영 내용
<!-- 이번 PR에서 작업한 내용을 간단히 설명해주세요 -->
- JWT 필터를 빈으로 등록을 제거하여 default 필터가 아닌 시큐리티 필터 체인에 등록했습니다. 때문에 시큐리티 설정으로만 필터를 타게할 url을 설정할 수 있습니다.
- 개발 서버 vm 성능이 좋지 않아 헬스 체크 시간 간격을 상향했습니다.
- swagger 생성을 이미지 빌드에 포함 시켰습니다.

## ✅ 체크리스트
- [x] 코드 컨벤션을 지켰나요?
- [ ] 테스트 케이스를 작성했나요?
- [x] 빌드가 정상적으로 됐나요?
- [x] 본인(작성자)를 assign 했나요?

## 🔗 관련 이슈
<!-- ex. Close #123 -->
Close # N/A

## 👀 리뷰어에게 바라는 점
<!-- 코드에서 중점적으로 봐줬으면 하는 부분이나, 궁금한 부분을 자유롭게 작성해주세요 -->
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Docker 이미지 빌드시 추가 Gradle 작업(`copyToSwagger`)이 실행됩니다.
  - 배포 스크립트의 헬스 체크 대기 시간이 3초에서 10초로 늘어났습니다.

- **Refactor**
  - 인증 필터 및 시큐리티 설정이 개선되어, 인증 관련 의존성 주입 방식이 변경되었습니다.  
  - 인증 관련 허용 URL 목록이 코드 내 상수로 분리되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->