### PR TITLE
[Feat] 온보딩 요구사항 구현

### DIFF
--- a/src/main/kotlin/com/yapp/demo/auth/controller/AuthController.kt
+++ b/src/main/kotlin/com/yapp/demo/auth/controller/AuthController.kt
@@ -25,7 +25,7 @@ class AuthController(
         @RequestBody @Valid
         request: OAuthLoginRequest,
     ): ApiResponse<OAuthLoginResponse> {
-        return ApiResponse.success(authUseCase.login(request.provider, request.authorizationCode))
+        return ApiResponse.success(authUseCase.login(request))
     }
 
     @PostMapping("/refresh")

--- a/src/main/kotlin/com/yapp/demo/auth/dto/request/OAuthLoginRequest.kt
+++ b/src/main/kotlin/com/yapp/demo/auth/dto/request/OAuthLoginRequest.kt
@@ -9,4 +9,6 @@ data class OAuthLoginRequest(
     val provider: SocialProvider,
     @field:NotBlank(message = "인가 코드는 필수 입니다.")
     val authorizationCode: String,
+    @field:NotBlank(message = "디바이스 식별자는 필수 입니다.")
+    val deviceId: String,
 )

--- a/src/main/kotlin/com/yapp/demo/auth/dto/response/OAuthLoginResponse.kt
+++ b/src/main/kotlin/com/yapp/demo/auth/dto/response/OAuthLoginResponse.kt
@@ -3,4 +3,5 @@ package com.yapp.demo.auth.dto.response
 data class OAuthLoginResponse(
     val accessToken: String,
     val refreshToken: String,
+    val memberState: String,
 )

--- a/src/main/kotlin/com/yapp/demo/auth/service/AuthUseCase.kt
+++ b/src/main/kotlin/com/yapp/demo/auth/service/AuthUseCase.kt
@@ -3,6 +3,7 @@ package com.yapp.demo.auth.service
 import com.yapp.demo.auth.dto.request.OAuthLoginRequest
 import com.yapp.demo.auth.dto.response.OAuthLoginResponse
 import com.yapp.demo.auth.dto.response.RefreshTokenResponse
+import com.yapp.demo.common.enums.SocialProvider
 
 interface AuthUseCase {
     fun login(request: OAuthLoginRequest): OAuthLoginResponse

--- a/src/main/kotlin/com/yapp/demo/auth/service/AuthUseCase.kt
+++ b/src/main/kotlin/com/yapp/demo/auth/service/AuthUseCase.kt
@@ -1,14 +1,11 @@
 package com.yapp.demo.auth.service
 
+import com.yapp.demo.auth.dto.request.OAuthLoginRequest
 import com.yapp.demo.auth.dto.response.OAuthLoginResponse
 import com.yapp.demo.auth.dto.response.RefreshTokenResponse
-import com.yapp.demo.common.enums.SocialProvider
 
 interface AuthUseCase {
-    fun login(
-        socialProvider: SocialProvider,
-        code: String,
-    ): OAuthLoginResponse
+    fun login(request: OAuthLoginRequest): OAuthLoginResponse
 
     fun refreshToken(refreshToken: String): RefreshTokenResponse
 

--- a/src/main/kotlin/com/yapp/demo/member/controller/MemberController.kt
+++ b/src/main/kotlin/com/yapp/demo/member/controller/MemberController.kt
@@ -1,0 +1,34 @@
+package com.yapp.demo.member.controller
+
+import com.yapp.demo.common.dto.ApiResponse
+import com.yapp.demo.common.security.getMemberId
+import com.yapp.demo.member.dto.request.UpdateNicknameRequest
+import com.yapp.demo.member.dto.response.MemberResponse
+import com.yapp.demo.member.service.MemberUseCase
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+
+@RestController("/v1/members")
+class MemberController(
+    private val memberUseCase: MemberUseCase,
+) {
+    @GetMapping("/me")
+    fun getMyInfo(): ApiResponse<MemberResponse> = ApiResponse.success(memberUseCase.getMember(getMemberId()))
+
+    @PatchMapping("/me")
+    fun update(
+        @RequestBody
+        request: UpdateNicknameRequest,
+    ): ApiResponse<MemberResponse> = ApiResponse.success(memberUseCase.update(request.nickname))
+
+    @DeleteMapping("/me")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    fun withdraw() {
+        memberUseCase.remove(getMemberId())
+    }
+}

--- a/src/main/kotlin/com/yapp/demo/member/controller/MemberController.kt
+++ b/src/main/kotlin/com/yapp/demo/member/controller/MemberController.kt
@@ -5,6 +5,7 @@ import com.yapp.demo.common.security.getMemberId
 import com.yapp.demo.member.dto.request.UpdateNicknameRequest
 import com.yapp.demo.member.dto.response.MemberResponse
 import com.yapp.demo.member.service.MemberUseCase
+import jakarta.validation.Valid
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.RequestBody
@@ -21,7 +22,7 @@ class MemberController(
 
     @PatchMapping("/me")
     fun update(
-        @RequestBody
+        @Valid @RequestBody
         request: UpdateNicknameRequest,
     ): ApiResponse<MemberResponse> = ApiResponse.success(memberUseCase.update(request.nickname))
 }

--- a/src/main/kotlin/com/yapp/demo/member/controller/MemberController.kt
+++ b/src/main/kotlin/com/yapp/demo/member/controller/MemberController.kt
@@ -5,13 +5,10 @@ import com.yapp.demo.common.security.getMemberId
 import com.yapp.demo.member.dto.request.UpdateNicknameRequest
 import com.yapp.demo.member.dto.response.MemberResponse
 import com.yapp.demo.member.service.MemberUseCase
-import org.springframework.http.HttpStatus
-import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
@@ -27,10 +24,4 @@ class MemberController(
         @RequestBody
         request: UpdateNicknameRequest,
     ): ApiResponse<MemberResponse> = ApiResponse.success(memberUseCase.update(request.nickname))
-
-    @DeleteMapping("/me")
-    @ResponseStatus(HttpStatus.NO_CONTENT)
-    fun withdraw() {
-        memberUseCase.remove(getMemberId())
-    }
 }

--- a/src/main/kotlin/com/yapp/demo/member/controller/MemberController.kt
+++ b/src/main/kotlin/com/yapp/demo/member/controller/MemberController.kt
@@ -10,10 +10,12 @@ import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 
-@RestController("/v1/members")
+@RestController
+@RequestMapping("/v1/members")
 class MemberController(
     private val memberUseCase: MemberUseCase,
 ) {

--- a/src/main/kotlin/com/yapp/demo/member/dto/request/UpdateNicknameRequest.kt
+++ b/src/main/kotlin/com/yapp/demo/member/dto/request/UpdateNicknameRequest.kt
@@ -1,0 +1,8 @@
+package com.yapp.demo.member.dto.request
+
+import jakarta.validation.constraints.NotBlank
+
+data class UpdateNicknameRequest(
+    @field:NotBlank
+    val nickname: String,
+)

--- a/src/main/kotlin/com/yapp/demo/member/dto/response/MemberResponse.kt
+++ b/src/main/kotlin/com/yapp/demo/member/dto/response/MemberResponse.kt
@@ -4,13 +4,13 @@ import com.yapp.demo.member.model.Member
 
 data class MemberResponse(
     val nickname: String?,
-    val status: String,
+    val state: String,
 ) {
     companion object {
         fun from(member: Member) =
             MemberResponse(
                 nickname = member.nickname,
-                status = member.state.name,
+                state = member.state.name,
             )
     }
 }

--- a/src/main/kotlin/com/yapp/demo/member/dto/response/MemberResponse.kt
+++ b/src/main/kotlin/com/yapp/demo/member/dto/response/MemberResponse.kt
@@ -1,0 +1,16 @@
+package com.yapp.demo.member.dto.response
+
+import com.yapp.demo.member.model.Member
+
+data class MemberResponse(
+    val nickname: String?,
+    val status: String,
+) {
+    companion object {
+        fun from(member: Member) =
+            MemberResponse(
+                nickname = member.nickname,
+                status = member.state.name,
+            )
+    }
+}

--- a/src/main/kotlin/com/yapp/demo/member/infrastructure/MemberReader.kt
+++ b/src/main/kotlin/com/yapp/demo/member/infrastructure/MemberReader.kt
@@ -3,9 +3,9 @@ package com.yapp.demo.member.infrastructure
 import com.yapp.demo.member.model.Member
 
 interface MemberReader {
+    fun findByDeviceId(deviceId: String): Member?
+
     fun findById(memberId: Long): Member?
 
     fun getById(memberId: Long): Member
-
-    fun findByAuthEmail(email: String): Member?
 }

--- a/src/main/kotlin/com/yapp/demo/member/infrastructure/MemberWriter.kt
+++ b/src/main/kotlin/com/yapp/demo/member/infrastructure/MemberWriter.kt
@@ -4,4 +4,6 @@ import com.yapp.demo.member.model.Member
 
 interface MemberWriter {
     fun save(member: Member): Member
+
+    fun remove(member: Member)
 }

--- a/src/main/kotlin/com/yapp/demo/member/infrastructure/MemberWriter.kt
+++ b/src/main/kotlin/com/yapp/demo/member/infrastructure/MemberWriter.kt
@@ -4,6 +4,4 @@ import com.yapp.demo.member.model.Member
 
 interface MemberWriter {
     fun save(member: Member): Member
-
-    fun remove(member: Member)
 }

--- a/src/main/kotlin/com/yapp/demo/member/infrastructure/jpa/MemberEntity.kt
+++ b/src/main/kotlin/com/yapp/demo/member/infrastructure/jpa/MemberEntity.kt
@@ -4,7 +4,7 @@ import com.yapp.demo.common.enums.Role
 import com.yapp.demo.common.enums.SocialProvider
 import com.yapp.demo.common.persistence.Auditable
 import com.yapp.demo.member.model.Member
-import com.yapp.demo.member.model.MemberStatus
+import com.yapp.demo.member.model.MemberState
 import jakarta.persistence.Entity
 import jakarta.persistence.EnumType
 import jakarta.persistence.Enumerated
@@ -12,7 +12,6 @@ import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
 import jakarta.persistence.Table
-import java.time.LocalDateTime
 
 @Table(name = "member")
 @Entity
@@ -20,35 +19,36 @@ class MemberEntity(
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     val memberId: Long = 0L,
+    val deviceId: String,
     val authEmail: String,
     @Enumerated(EnumType.STRING)
     val socialProvider: SocialProvider,
     @Enumerated(EnumType.STRING)
     val role: Role,
-    val deletedAt: LocalDateTime? = null,
-    status: MemberStatus,
+    state: MemberState,
     nickname: String? = null,
 ) : Auditable() {
     var nickname: String? = nickname
         protected set
 
     @Enumerated(EnumType.STRING)
-    var status: MemberStatus = status
+    var state: MemberState = state
         protected set
 
     fun update(entity: MemberEntity) {
         nickname = entity.nickname
-        status = entity.status
+        state = entity.state
     }
 
     fun toDomain() =
         Member(
             id = memberId,
+            deviceId = deviceId,
             authEmail = authEmail,
             nickname = nickname,
             socialProvider = socialProvider,
             role = role,
-            status = status,
+            state = state,
             createdAt = requireNotNull(createdAt),
             updatedAt = requireNotNull(updatedAt),
         )
@@ -56,11 +56,12 @@ class MemberEntity(
     companion object {
         fun from(member: Member) =
             MemberEntity(
+                deviceId = member.deviceId,
                 authEmail = member.authEmail,
                 nickname = member.nickname,
                 socialProvider = member.socialProvider,
                 role = member.role,
-                status = member.status,
+                state = member.state,
             )
     }
 }

--- a/src/main/kotlin/com/yapp/demo/member/infrastructure/jpa/MemberJpaReader.kt
+++ b/src/main/kotlin/com/yapp/demo/member/infrastructure/jpa/MemberJpaReader.kt
@@ -11,6 +11,10 @@ import kotlin.jvm.optionals.getOrNull
 class MemberJpaReader(
     private val memberRepository: MemberRepository,
 ) : MemberReader {
+    override fun findByDeviceId(deviceId: String): Member? =
+        memberRepository.findByDeviceId(deviceId)
+            ?.toDomain()
+
     override fun findById(memberId: Long): Member? =
         memberRepository.findById(memberId)
             .getOrNull()
@@ -21,6 +25,4 @@ class MemberJpaReader(
             .getOrNull()
             ?.toDomain()
             ?: throw CustomException(ErrorCode.MEMBER_NOT_FOUND)
-
-    override fun findByAuthEmail(email: String): Member? = memberRepository.findByAuthEmail(email)?.toDomain()
 }

--- a/src/main/kotlin/com/yapp/demo/member/infrastructure/jpa/MemberJpaWriter.kt
+++ b/src/main/kotlin/com/yapp/demo/member/infrastructure/jpa/MemberJpaWriter.kt
@@ -12,4 +12,8 @@ class MemberJpaWriter(
         val entity = MemberEntity.from(member)
         return memberRepository.save(entity).toDomain()
     }
+
+    override fun remove(member: Member) {
+        memberRepository.delete(MemberEntity.from(member))
+    }
 }

--- a/src/main/kotlin/com/yapp/demo/member/infrastructure/jpa/MemberJpaWriter.kt
+++ b/src/main/kotlin/com/yapp/demo/member/infrastructure/jpa/MemberJpaWriter.kt
@@ -12,8 +12,4 @@ class MemberJpaWriter(
         val entity = MemberEntity.from(member)
         return memberRepository.save(entity).toDomain()
     }
-
-    override fun remove(member: Member) {
-        memberRepository.delete(MemberEntity.from(member))
-    }
 }

--- a/src/main/kotlin/com/yapp/demo/member/infrastructure/jpa/MemberRepository.kt
+++ b/src/main/kotlin/com/yapp/demo/member/infrastructure/jpa/MemberRepository.kt
@@ -3,5 +3,5 @@ package com.yapp.demo.member.infrastructure.jpa
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface MemberRepository : JpaRepository<MemberEntity, Long> {
-    fun findByAuthEmail(authEmail: String): MemberEntity?
+    fun findByDeviceId(deviceId: String): MemberEntity?
 }

--- a/src/main/kotlin/com/yapp/demo/member/model/Member.kt
+++ b/src/main/kotlin/com/yapp/demo/member/model/Member.kt
@@ -7,32 +7,34 @@ import java.time.LocalDateTime
 data class Member(
     val id: Long = 0L,
     var nickname: String? = null,
+    val deviceId: String,
     val authEmail: String,
     val socialProvider: SocialProvider,
     val role: Role,
-    var status: MemberStatus,
+    var state: MemberState,
     val createdAt: LocalDateTime? = null,
     var updatedAt: LocalDateTime? = null,
-    var deletedAt: LocalDateTime? = null,
 ) {
     fun update(
         nickname: String? = this.nickname,
-        status: MemberStatus = this.status,
+        status: MemberState = this.state,
     ) = copy(
         nickname = nickname,
-        status = status,
+        state = status,
     )
 
     companion object {
         fun create(
+            deviceId: String,
             authEmail: String,
             socialProvider: SocialProvider,
             role: Role,
         ) = Member(
+            deviceId = deviceId,
             authEmail = authEmail,
             socialProvider = socialProvider,
             role = role,
-            status = MemberStatus.ACTIVE,
+            state = MemberState.HOLD,
         )
     }
 }

--- a/src/main/kotlin/com/yapp/demo/member/model/MemberState.kt
+++ b/src/main/kotlin/com/yapp/demo/member/model/MemberState.kt
@@ -3,10 +3,9 @@ package com.yapp.demo.member.model
 import com.yapp.demo.common.exception.CustomException
 import com.yapp.demo.common.exception.ErrorCode.BAD_REQUEST
 
-enum class MemberStatus {
+enum class MemberState {
     HOLD,
     ACTIVE,
-    DELETED,
     ;
 
     companion object {

--- a/src/main/kotlin/com/yapp/demo/member/service/MemberService.kt
+++ b/src/main/kotlin/com/yapp/demo/member/service/MemberService.kt
@@ -1,0 +1,32 @@
+package com.yapp.demo.member.service
+
+import com.yapp.demo.common.security.getMemberId
+import com.yapp.demo.member.dto.response.MemberResponse
+import com.yapp.demo.member.infrastructure.MemberReader
+import com.yapp.demo.member.infrastructure.MemberWriter
+import com.yapp.demo.member.model.MemberState
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class MemberService(
+    private val memberReader: MemberReader,
+    private val memberWriter: MemberWriter,
+) : MemberUseCase {
+    @Transactional(readOnly = true)
+    override fun getMember(memberId: Long): MemberResponse = MemberResponse.from(memberReader.getById(memberId))
+
+    @Transactional
+    override fun update(nickname: String): MemberResponse {
+        val member =
+            memberReader.getById(getMemberId())
+                .update(nickname, MemberState.ACTIVE)
+
+        return MemberResponse.from(memberWriter.save(member))
+    }
+
+    @Transactional
+    override fun remove(memberId: Long) {
+        memberWriter.remove(memberReader.getById(memberId))
+    }
+}

--- a/src/main/kotlin/com/yapp/demo/member/service/MemberService.kt
+++ b/src/main/kotlin/com/yapp/demo/member/service/MemberService.kt
@@ -24,9 +24,4 @@ class MemberService(
 
         return MemberResponse.from(memberWriter.save(member))
     }
-
-    @Transactional
-    override fun remove(memberId: Long) {
-        memberWriter.remove(memberReader.getById(memberId))
-    }
 }

--- a/src/main/kotlin/com/yapp/demo/member/service/MemberUseCase.kt
+++ b/src/main/kotlin/com/yapp/demo/member/service/MemberUseCase.kt
@@ -1,0 +1,11 @@
+package com.yapp.demo.member.service
+
+import com.yapp.demo.member.dto.response.MemberResponse
+
+interface MemberUseCase {
+    fun getMember(memberId: Long): MemberResponse
+
+    fun update(nickname: String): MemberResponse
+
+    fun remove(memberId: Long)
+}

--- a/src/main/kotlin/com/yapp/demo/member/service/MemberUseCase.kt
+++ b/src/main/kotlin/com/yapp/demo/member/service/MemberUseCase.kt
@@ -6,6 +6,4 @@ interface MemberUseCase {
     fun getMember(memberId: Long): MemberResponse
 
     fun update(nickname: String): MemberResponse
-
-    fun remove(memberId: Long)
 }

--- a/src/main/resources/db/migration/V2__add_member_device_id_column.sql
+++ b/src/main/resources/db/migration/V2__add_member_device_id_column.sql
@@ -2,4 +2,7 @@ ALTER TABLE `member`
 ADD COLUMN device_id VARCHAR(255) NOT NULL AFTER member_id;
 
 ALTER TABLE `member`
+ADD CONSTRAINT uq_member_device_id UNIQUE (device_id);
+
+ALTER TABLE `member`
 DROP COLUMN deleted_at;

--- a/src/main/resources/db/migration/V2__add_member_device_id_column.sql
+++ b/src/main/resources/db/migration/V2__add_member_device_id_column.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `member`
+ADD COLUMN device_id VARCHAR(255) NOT NULL AFTER member_id;

--- a/src/main/resources/db/migration/V2__add_member_device_id_column.sql
+++ b/src/main/resources/db/migration/V2__add_member_device_id_column.sql
@@ -1,2 +1,5 @@
 ALTER TABLE `member`
 ADD COLUMN device_id VARCHAR(255) NOT NULL AFTER member_id;
+
+ALTER TABLE `member`
+DROP COLUMN deleted_at;

--- a/src/test/kotlin/com/yapp/demo/auth/controller/AuthControllerTest.kt
+++ b/src/test/kotlin/com/yapp/demo/auth/controller/AuthControllerTest.kt
@@ -6,7 +6,6 @@ import com.yapp.demo.auth.dto.request.OAuthLoginRequest
 import com.yapp.demo.auth.dto.request.RefreshTokenRequest
 import com.yapp.demo.auth.dto.response.OAuthLoginResponse
 import com.yapp.demo.auth.dto.response.RefreshTokenResponse
-import com.yapp.demo.auth.service.AuthUseCase
 import com.yapp.demo.common.dto.ApiResponse
 import com.yapp.demo.common.enums.SocialProvider
 import com.yapp.demo.member.model.MemberState
@@ -21,16 +20,12 @@ import org.mockito.Mockito.`when`
 import org.mockito.kotlin.doNothing
 import org.springframework.http.MediaType
 import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders
-import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import requestBody
 import responseBody
 import java.util.UUID
 
 class AuthControllerTest : RestApiTestBase() {
-    @MockitoBean
-    lateinit var authUseCase: AuthUseCase
-
     @Test
     fun `로그인 API`() {
         val request =

--- a/src/test/kotlin/com/yapp/demo/auth/controller/AuthControllerTest.kt
+++ b/src/test/kotlin/com/yapp/demo/auth/controller/AuthControllerTest.kt
@@ -9,6 +9,7 @@ import com.yapp.demo.auth.dto.response.RefreshTokenResponse
 import com.yapp.demo.auth.service.AuthUseCase
 import com.yapp.demo.common.dto.ApiResponse
 import com.yapp.demo.common.enums.SocialProvider
+import com.yapp.demo.member.model.MemberState
 import com.yapp.demo.support.RestApiTestBase
 import com.yapp.demo.support.restdocs.NUMBER
 import com.yapp.demo.support.restdocs.OBJECT
@@ -24,6 +25,7 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import requestBody
 import responseBody
+import java.util.UUID
 
 class AuthControllerTest : RestApiTestBase() {
     @MockitoBean
@@ -31,10 +33,23 @@ class AuthControllerTest : RestApiTestBase() {
 
     @Test
     fun `로그인 API`() {
-        val request = OAuthLoginRequest(SocialProvider.KAKAO, "authorization-code")
-        val response = ApiResponse.success(OAuthLoginResponse("access-token", "refresh-token"))
+        val request =
+            OAuthLoginRequest(
+                SocialProvider.KAKAO,
+                "authorization-code",
+                UUID.randomUUID().toString(),
+            )
 
-        `when`(authUseCase.login(request.provider, request.authorizationCode))
+        val response =
+            ApiResponse.success(
+                OAuthLoginResponse(
+                    "access-token",
+                    "refresh-token",
+                    MemberState.ACTIVE.name,
+                ),
+            )
+
+        `when`(authUseCase.login(request))
             .thenReturn(response.data)
 
         val builder =
@@ -49,11 +64,13 @@ class AuthControllerTest : RestApiTestBase() {
                 requestBody(
                     "provider" type STRING means "소셜 로그인 타입",
                     "authorizationCode" type STRING means "인가 코드",
+                    "deviceId" type STRING means "모바일 디바이스 식별자",
                 ),
                 responseBody(
                     "data" type OBJECT means "응답 바디",
                     "data.accessToken" type STRING means "액세스 토큰",
                     "data.refreshToken" type STRING means "리프레시 토큰",
+                    "data.memberState" type STRING means "유저의 상태 ",
                     "code" type NUMBER means "HTTP 코드",
                 ),
             )

--- a/src/test/kotlin/com/yapp/demo/auth/service/AuthServiceTest.kt
+++ b/src/test/kotlin/com/yapp/demo/auth/service/AuthServiceTest.kt
@@ -16,9 +16,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
-import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.Mockito.`when`
-import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
@@ -26,7 +24,6 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.context.SecurityContextHolder
 import java.time.Duration
 
-@ExtendWith(MockitoExtension::class)
 class AuthServiceTest {
     private val userInfo = OAuthUserInfo("id", "test@email.com")
     private val code = "authCode"

--- a/src/test/kotlin/com/yapp/demo/auth/service/AuthServiceTest.kt
+++ b/src/test/kotlin/com/yapp/demo/auth/service/AuthServiceTest.kt
@@ -1,18 +1,17 @@
 package com.yapp.demo.auth.service
 
+import com.yapp.demo.auth.dto.request.OAuthLoginRequest
 import com.yapp.demo.auth.infrastructure.BlackListRepository
 import com.yapp.demo.auth.infrastructure.RefreshTokenRepository
 import com.yapp.demo.common.constants.TOKEN_TYPE_REFRESH
-import com.yapp.demo.common.enums.Role
 import com.yapp.demo.common.enums.SocialProvider
 import com.yapp.demo.common.exception.CustomException
 import com.yapp.demo.common.exception.ErrorCode
 import com.yapp.demo.member.infrastructure.jpa.MemberJpaReader
 import com.yapp.demo.member.infrastructure.jpa.MemberJpaWriter
-import com.yapp.demo.member.model.Member
-import com.yapp.demo.member.model.MemberStatus
 import com.yapp.demo.oauth.model.OAuthUserInfo
 import com.yapp.demo.oauth.service.OAuthProvider
+import com.yapp.demo.support.fixture.model.memberFixture
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -23,7 +22,6 @@ import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
-import org.mockito.kotlin.whenever
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
 import org.springframework.security.core.context.SecurityContextHolder
 import java.time.Duration
@@ -62,23 +60,24 @@ class AuthServiceTest {
         val provider = SocialProvider.KAKAO
         val accessToken = "access-token"
         val refreshToken = "refresh-token"
-        val member =
-            Member(
-                id = 1L,
-                authEmail = userInfo.email,
-                socialProvider = provider,
-                role = Role.USER,
-                status = MemberStatus.ACTIVE,
+
+        val member = memberFixture(id = 1L, authEmail = userInfo.email)
+
+        val request =
+            OAuthLoginRequest(
+                provider = provider,
+                authorizationCode = code,
+                deviceId = member.deviceId,
             )
 
-        whenever(memberReader.findByAuthEmail(userInfo.email)).thenReturn(member)
+        `when`(memberReader.findByDeviceId(member.deviceId)).thenReturn(member)
 
-        whenever(jwtTokenProvider.generateAccessToken(member.id)).thenReturn(accessToken)
-        whenever(jwtTokenProvider.generateRefreshToken(member.id)).thenReturn(refreshToken)
-        whenever(jwtTokenProvider.extractExpiration(refreshToken)).thenReturn(60000L)
+        `when`(jwtTokenProvider.generateAccessToken(member.id)).thenReturn(accessToken)
+        `when`(jwtTokenProvider.generateRefreshToken(member.id)).thenReturn(refreshToken)
+        `when`(jwtTokenProvider.extractExpiration(refreshToken)).thenReturn(60000L)
 
         // when
-        val result = authService.login(provider, code)
+        val result = authService.login(request)
 
         // then
         assertThat(result.accessToken).isEqualTo(accessToken)
@@ -89,14 +88,7 @@ class AuthServiceTest {
     inner class RefreshTokenTest {
         private val refreshToken = "refresh-token"
         private val memberId = 1L
-        private val member =
-            Member(
-                id = memberId,
-                authEmail = userInfo.email,
-                socialProvider = SocialProvider.KAKAO,
-                role = Role.USER,
-                status = MemberStatus.ACTIVE,
-            )
+        private val member = memberFixture(id = 1, authEmail = userInfo.email)
 
         @Test
         fun `refresh는 새로운 리프레시 토큰과 액세스 토큰을 발급한다`() {

--- a/src/test/kotlin/com/yapp/demo/auth/service/JwtTokenProviderTest.kt
+++ b/src/test/kotlin/com/yapp/demo/auth/service/JwtTokenProviderTest.kt
@@ -9,7 +9,7 @@ import com.yapp.demo.common.exception.CustomException
 import com.yapp.demo.common.exception.ErrorCode
 import com.yapp.demo.member.infrastructure.jpa.MemberJpaReader
 import com.yapp.demo.member.model.Member
-import com.yapp.demo.member.model.MemberStatus
+import com.yapp.demo.member.model.MemberState
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.assertThrows
@@ -18,6 +18,7 @@ import org.mockito.Mockito.`when`
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.mock
 import org.springframework.security.core.authority.SimpleGrantedAuthority
+import java.util.UUID
 import kotlin.test.Test
 import kotlin.test.assertTrue
 
@@ -93,10 +94,11 @@ class JwtTokenProviderTest {
         val member =
             Member(
                 id = memberId,
+                deviceId = UUID.randomUUID().toString(),
                 authEmail = "email@email.com",
                 socialProvider = SocialProvider.KAKAO,
                 role = Role.USER,
-                status = MemberStatus.ACTIVE,
+                state = MemberState.ACTIVE,
             )
 
         `when`(memberReader.findById(memberId)).thenReturn(member)

--- a/src/test/kotlin/com/yapp/demo/member/controller/MemberControllerTest.kt
+++ b/src/test/kotlin/com/yapp/demo/member/controller/MemberControllerTest.kt
@@ -13,7 +13,6 @@ import com.yapp.demo.support.restdocs.toJsonString
 import com.yapp.demo.support.restdocs.type
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito.`when`
-import org.mockito.kotlin.doNothing
 import org.springframework.http.MediaType
 import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
@@ -59,8 +58,6 @@ class MemberControllerTest : RestApiTestBase() {
 
     @Test
     fun `내정보 수정 API`() {
-        val memberId = 1L
-
         val request =
             UpdateNicknameRequest(
                 nickname = "modifiedNickname",
@@ -94,26 +91,5 @@ class MemberControllerTest : RestApiTestBase() {
                     "code" type NUMBER means "HTTP 코드",
                 ),
             )
-    }
-
-    @Test
-    fun `탈퇴 API`() {
-        val memberId = 1L
-
-        // SecurityContext 설정
-        val authentication = UsernamePasswordAuthenticationToken(memberId.toString(), null)
-        SecurityContextHolder.getContext().authentication = authentication
-
-        doNothing().`when`(memberUseCase).remove(memberId)
-
-        val builder = RestDocumentationRequestBuilders.delete("/v1/members/me")
-
-        mockMvc.perform(builder)
-            .andExpect(status().isNoContent)
-            .andDocument(
-                "members-me-delete",
-            )
-
-        SecurityContextHolder.clearContext()
     }
 }

--- a/src/test/kotlin/com/yapp/demo/member/controller/MemberControllerTest.kt
+++ b/src/test/kotlin/com/yapp/demo/member/controller/MemberControllerTest.kt
@@ -1,0 +1,5 @@
+package com.yapp.demo.member.controller
+
+import com.yapp.demo.support.RestApiTestBase
+
+class MemberControllerTest : RestApiTestBase()

--- a/src/test/kotlin/com/yapp/demo/member/controller/MemberControllerTest.kt
+++ b/src/test/kotlin/com/yapp/demo/member/controller/MemberControllerTest.kt
@@ -1,5 +1,119 @@
 package com.yapp.demo.member.controller
 
+import andDocument
+import com.yapp.demo.common.dto.ApiResponse
+import com.yapp.demo.member.dto.request.UpdateNicknameRequest
+import com.yapp.demo.member.dto.response.MemberResponse
+import com.yapp.demo.member.model.MemberState
 import com.yapp.demo.support.RestApiTestBase
+import com.yapp.demo.support.restdocs.NUMBER
+import com.yapp.demo.support.restdocs.OBJECT
+import com.yapp.demo.support.restdocs.STRING
+import com.yapp.demo.support.restdocs.toJsonString
+import com.yapp.demo.support.restdocs.type
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.`when`
+import org.mockito.kotlin.doNothing
+import org.springframework.http.MediaType
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import requestBody
+import responseBody
 
-class MemberControllerTest : RestApiTestBase()
+class MemberControllerTest : RestApiTestBase() {
+    @Test
+    fun `내정보 조회 API`() {
+        val memberId = 1L
+        val response =
+            ApiResponse.success(
+                MemberResponse(
+                    nickname = "brake-nickname",
+                    state = MemberState.ACTIVE.name,
+                ),
+            )
+
+        // SecurityContext 설정
+        val authentication = UsernamePasswordAuthenticationToken(memberId.toString(), null)
+        SecurityContextHolder.getContext().authentication = authentication
+
+        `when`(memberUseCase.getMember(memberId)).thenReturn(response.data)
+
+        val builder = RestDocumentationRequestBuilders.get("/v1/members/me")
+
+        mockMvc.perform(builder)
+            .andExpect(status().isOk)
+            .andDocument(
+                "members-me-get",
+                responseBody(
+                    "data" type OBJECT means "응답 바디",
+                    "data.nickname" type STRING means "닉네임",
+                    "data.state" type STRING means "상태",
+                    "code" type NUMBER means "HTTP 코드",
+                ),
+            )
+
+        SecurityContextHolder.clearContext()
+    }
+
+    @Test
+    fun `내정보 수정 API`() {
+        val memberId = 1L
+
+        val request =
+            UpdateNicknameRequest(
+                nickname = "modifiedNickname",
+            )
+        val response =
+            ApiResponse.success(
+                MemberResponse(
+                    nickname = request.nickname,
+                    state = MemberState.ACTIVE.name,
+                ),
+            )
+
+        `when`(memberUseCase.update(request.nickname)).thenReturn(response.data)
+
+        val builder =
+            RestDocumentationRequestBuilders.patch("/v1/members/me")
+                .content(request.toJsonString())
+                .contentType(MediaType.APPLICATION_JSON)
+
+        mockMvc.perform(builder)
+            .andExpect(status().isOk)
+            .andDocument(
+                "members-me-update",
+                requestBody(
+                    "nickname" type STRING means "변경하려는 닉네임",
+                ),
+                responseBody(
+                    "data" type OBJECT means "응답 바디",
+                    "data.nickname" type STRING means "닉네임",
+                    "data.state" type STRING means "상태",
+                    "code" type NUMBER means "HTTP 코드",
+                ),
+            )
+    }
+
+    @Test
+    fun `탈퇴 API`() {
+        val memberId = 1L
+
+        // SecurityContext 설정
+        val authentication = UsernamePasswordAuthenticationToken(memberId.toString(), null)
+        SecurityContextHolder.getContext().authentication = authentication
+
+        doNothing().`when`(memberUseCase).remove(memberId)
+
+        val builder = RestDocumentationRequestBuilders.delete("/v1/members/me")
+
+        mockMvc.perform(builder)
+            .andExpect(status().isNoContent)
+            .andDocument(
+                "members-me-delete",
+            )
+
+        SecurityContextHolder.clearContext()
+    }
+}

--- a/src/test/kotlin/com/yapp/demo/member/service/MemberServiceTest.kt
+++ b/src/test/kotlin/com/yapp/demo/member/service/MemberServiceTest.kt
@@ -1,0 +1,80 @@
+package com.yapp.demo.member.service
+
+import com.yapp.demo.common.exception.CustomException
+import com.yapp.demo.common.exception.ErrorCode
+import com.yapp.demo.member.infrastructure.MemberReader
+import com.yapp.demo.member.infrastructure.MemberWriter
+import com.yapp.demo.support.fixture.model.memberFixture
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.assertThrows
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.context.SecurityContextHolder
+
+class MemberServiceTest {
+    private val memberReader = mock<MemberReader>()
+    private val memberWriter = mock<MemberWriter>()
+    private val memberService = MemberService(memberReader, memberWriter)
+
+    @Nested
+    inner class GetMemberTest {
+        @Test
+        fun `getMember()는 유저가 존재하면 식별자로 조회가 가능하다`() {
+            val expected = memberFixture(id = 1L, nickname = "brake-user")
+
+            `when`(memberReader.getById(memberId = expected.id)).thenReturn(expected)
+
+            val result = memberService.getMember(expected.id)
+
+            assertThat(result.nickname).isEqualTo(expected.nickname)
+        }
+
+        @Test
+        fun `getMember()는 유저가 존재하지 않으면 예외를 던진다`() {
+            val invalidId = 12124124L
+            `when`(memberReader.getById(invalidId)).thenThrow(CustomException(ErrorCode.MEMBER_NOT_FOUND))
+
+            val result =
+                assertThrows<CustomException> {
+                    memberService.getMember(invalidId)
+                }
+
+            assertThat(result.errorCode).isEqualTo(ErrorCode.MEMBER_NOT_FOUND)
+        }
+    }
+
+    @Test
+    fun `update()는 유저가 존재하면 유저 정보를 변경한다`() {
+        val newNickname = "brake-user-modified"
+        val member = memberFixture(id = 1L, nickname = "brake-user")
+        val expected = memberFixture(id = member.id, nickname = newNickname)
+
+        // SecurityContext 설정
+        val authentication = UsernamePasswordAuthenticationToken(member.id.toString(), null)
+        SecurityContextHolder.getContext().authentication = authentication
+
+        `when`(memberReader.getById(memberId = member.id)).thenReturn(expected)
+        `when`(memberWriter.save(expected)).thenReturn(expected)
+
+        val result = memberService.update(newNickname)
+
+        assertThat(result.nickname).isEqualTo(expected.nickname)
+
+        SecurityContextHolder.clearContext()
+    }
+
+    @Test
+    fun `remove()는 유저를 삭제 한다`() {
+        val member = memberFixture(id = 1L, nickname = "brake-user")
+
+        `when`(memberReader.getById(memberId = member.id)).thenReturn(member)
+
+        assertDoesNotThrow {
+            memberService.remove(1L)
+        }
+    }
+}

--- a/src/test/kotlin/com/yapp/demo/member/service/MemberServiceTest.kt
+++ b/src/test/kotlin/com/yapp/demo/member/service/MemberServiceTest.kt
@@ -8,7 +8,6 @@ import com.yapp.demo.support.fixture.model.memberFixture
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.`when`
@@ -65,16 +64,5 @@ class MemberServiceTest {
         assertThat(result.nickname).isEqualTo(expected.nickname)
 
         SecurityContextHolder.clearContext()
-    }
-
-    @Test
-    fun `remove()는 유저를 삭제 한다`() {
-        val member = memberFixture(id = 1L, nickname = "brake-user")
-
-        `when`(memberReader.getById(memberId = member.id)).thenReturn(member)
-
-        assertDoesNotThrow {
-            memberService.remove(1L)
-        }
     }
 }

--- a/src/test/kotlin/com/yapp/demo/member/service/MemberServiceTest.kt
+++ b/src/test/kotlin/com/yapp/demo/member/service/MemberServiceTest.kt
@@ -4,6 +4,7 @@ import com.yapp.demo.common.exception.CustomException
 import com.yapp.demo.common.exception.ErrorCode
 import com.yapp.demo.member.infrastructure.MemberReader
 import com.yapp.demo.member.infrastructure.MemberWriter
+import com.yapp.demo.member.model.MemberState
 import com.yapp.demo.support.fixture.model.memberFixture
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
@@ -11,6 +12,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.`when`
+import org.mockito.kotlin.any
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
 import org.springframework.security.core.context.SecurityContextHolder
 
@@ -49,19 +51,20 @@ class MemberServiceTest {
     @Test
     fun `update()는 유저가 존재하면 유저 정보를 변경한다`() {
         val newNickname = "brake-user-modified"
-        val member = memberFixture(id = 1L, nickname = "brake-user")
+        val member = memberFixture(id = 1L, nickname = "brake-user", state = MemberState.HOLD)
         val expected = memberFixture(id = member.id, nickname = newNickname)
 
         // SecurityContext 설정
         val authentication = UsernamePasswordAuthenticationToken(member.id.toString(), null)
         SecurityContextHolder.getContext().authentication = authentication
 
-        `when`(memberReader.getById(memberId = member.id)).thenReturn(expected)
-        `when`(memberWriter.save(expected)).thenReturn(expected)
+        `when`(memberReader.getById(memberId = member.id)).thenReturn(member)
+        `when`(memberWriter.save(any())).thenReturn(expected)
 
         val result = memberService.update(newNickname)
 
         assertThat(result.nickname).isEqualTo(expected.nickname)
+        assertThat(result.state).isEqualTo(MemberState.ACTIVE.name)
 
         SecurityContextHolder.clearContext()
     }

--- a/src/test/kotlin/com/yapp/demo/support/RestApiTestBase.kt
+++ b/src/test/kotlin/com/yapp/demo/support/RestApiTestBase.kt
@@ -1,7 +1,10 @@
 package com.yapp.demo.support
 
 import com.yapp.demo.auth.controller.AuthController
+import com.yapp.demo.auth.service.AuthUseCase
 import com.yapp.demo.common.filter.JwtAuthenticationFilter
+import com.yapp.demo.member.controller.MemberController
+import com.yapp.demo.member.service.MemberUseCase
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs
@@ -20,11 +23,18 @@ import org.springframework.web.context.WebApplicationContext
 @WebMvcTest(
     controllers = [
         AuthController::class,
+        MemberController::class,
     ],
 )
 abstract class RestApiTestBase {
     @MockitoBean
     lateinit var jwtAuthenticationFilter: JwtAuthenticationFilter
+
+    @MockitoBean
+    lateinit var authUseCase: AuthUseCase
+
+    @MockitoBean
+    lateinit var memberUseCase: MemberUseCase
 
     lateinit var mockMvc: MockMvc
 

--- a/src/test/kotlin/com/yapp/demo/support/fixture/model/MemberFixture.kt
+++ b/src/test/kotlin/com/yapp/demo/support/fixture/model/MemberFixture.kt
@@ -1,0 +1,30 @@
+package com.yapp.demo.support.fixture.model
+
+import com.yapp.demo.common.enums.Role
+import com.yapp.demo.common.enums.SocialProvider
+import com.yapp.demo.member.model.Member
+import com.yapp.demo.member.model.MemberState
+import java.time.LocalDateTime
+import java.util.UUID
+
+fun memberFixture(
+    id: Long = 0L,
+    nickname: String? = null,
+    authEmail: String = "brake@kakao.com",
+    deviceId: String = UUID.randomUUID().toString(),
+    socialProvider: SocialProvider = SocialProvider.KAKAO,
+    role: Role = Role.USER,
+    state: MemberState = MemberState.ACTIVE,
+    createdAt: LocalDateTime? = null,
+    updatedAt: LocalDateTime? = null,
+) = Member(
+    id = id,
+    nickname = nickname,
+    authEmail = authEmail,
+    deviceId = deviceId,
+    socialProvider = socialProvider,
+    role = role,
+    state = state,
+    createdAt = createdAt,
+    updatedAt = updatedAt,
+)


### PR DESCRIPTION
## 🔍 반영 내용
<!-- 이번 PR에서 작업한 내용을 간단히 설명해주세요 -->
- 회원가입 후 온보딩 과정에 필요한 요구 사항을 구현했습니다.
   - 유저 닉네임 수정 및 유저 상태 변경 로직 추가
- 로그인 dto 수정
   - 요청: 디바이스 식별자 추가
   - 응답: 유저 상태 추가
- 로그인 시 이메일이 아닌 디바이스 식별자로 유저 조회하도록 수정
## ✅ 체크리스트
- [x] 코드 컨벤션을 지켰나요?
- [x] 테스트 케이스를 작성했나요?
- [x] 빌드가 정상적으로 됐나요?
- [x] 본인(작성자)를 assign 했나요?

## 🔗 관련 이슈
<!-- ex. Close #123 -->
Close #21 

## 👀 리뷰어에게 바라는 점
<!-- 코드에서 중점적으로 봐줬으면 하는 부분이나, 궁금한 부분을 자유롭게 작성해주세요 -->
- 탈퇴 로직은 관심사 분리 관련 회의 내용 결과 나오고 개발 하는게 좋을 것 같아요. 그리고 아연님 애플 탈퇴 로직 머지 후에 작성하는 것이 개발하기 수월 할 것 같아서 제외했습니다!
- 이 pr은 아연님 로직 머지 후에 머지하겠습니다 🙏 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 회원 정보 조회 및 닉네임 수정 API가 추가되었습니다.
  * 회원 상태(state) 및 디바이스 식별자(deviceId) 필드가 회원 관련 응답 및 요청에 포함됩니다.

* **기능 개선**
  * 로그인 요청 시 디바이스 식별자(deviceId) 입력이 필수로 변경되었습니다.
  * 로그인 응답에 회원 상태(memberState)가 추가되었습니다.
  * 회원 조회 및 수정 시 이메일 기반 조회에서 디바이스 ID 기반 조회로 변경되었습니다.
  * 회원 상태 enum에서 DELETED 상태가 제거되고 HOLD, ACTIVE 상태만 남았습니다.
  * 회원 엔티티 및 도메인 모델에서 상태(status) 명칭이 상태(state)로 변경되었습니다.

* **테스트**
  * 회원 및 인증 관련 신규/변경 API에 대한 테스트 코드와 테스트 픽스처가 추가 및 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->