### PR TITLE
[Refactor] self-invocation으로 인해 트랜잭션(AOP)가 안잡히는 현상 수정

### DIFF
--- a/src/main/kotlin/com/yapp/brake/auth/service/AuthService.kt
+++ b/src/main/kotlin/com/yapp/brake/auth/service/AuthService.kt
@@ -17,7 +17,6 @@ import com.yapp.brake.member.model.Member
 import com.yapp.brake.oauth.model.OAuthUserInfo
 import com.yapp.brake.oauth.service.OAuthProvider
 import org.springframework.stereotype.Service
-import org.springframework.transaction.annotation.Transactional
 import java.time.Duration
 
 @Service
@@ -85,8 +84,7 @@ class AuthService(
         memberWriter.delete(getMemberId())
     }
 
-    @Transactional
-    fun findOrCreateMember(
+    private fun findOrCreateMember(
         deviceId: String,
         userInfo: OAuthUserInfo,
     ): Member {

--- a/src/main/kotlin/com/yapp/brake/member/infrastructure/jpa/MemberJpaReader.kt
+++ b/src/main/kotlin/com/yapp/brake/member/infrastructure/jpa/MemberJpaReader.kt
@@ -5,9 +5,11 @@ import com.yapp.brake.common.exception.ErrorCode
 import com.yapp.brake.member.infrastructure.MemberReader
 import com.yapp.brake.member.model.Member
 import org.springframework.stereotype.Repository
+import org.springframework.transaction.annotation.Transactional
 import kotlin.jvm.optionals.getOrNull
 
 @Repository
+@Transactional(readOnly = true)
 class MemberJpaReader(
     private val memberRepository: MemberRepository,
 ) : MemberReader {

--- a/src/main/kotlin/com/yapp/brake/member/infrastructure/jpa/MemberJpaWriter.kt
+++ b/src/main/kotlin/com/yapp/brake/member/infrastructure/jpa/MemberJpaWriter.kt
@@ -3,8 +3,10 @@ package com.yapp.brake.member.infrastructure.jpa
 import com.yapp.brake.member.infrastructure.MemberWriter
 import com.yapp.brake.member.model.Member
 import org.springframework.stereotype.Repository
+import org.springframework.transaction.annotation.Transactional
 
 @Repository
+@Transactional
 class MemberJpaWriter(
     private val memberRepository: MemberRepository,
 ) : MemberWriter {


### PR DESCRIPTION
## 🔍 반영 내용
<!-- 이번 PR에서 작업한 내용을 간단히 설명해주세요 -->
- 제목 내용의 이슈로 인해 인프라 계층에 트랜잭션을 추가했습니다.

## ✅ 체크리스트
- [x] 코드 컨벤션을 지켰나요?
- [ ] 테스트 케이스를 작성했나요?
- [x] 빌드가 정상적으로 됐나요?
- [x] 본인(작성자)를 assign 했나요?

## 🔗 관련 이슈
<!-- ex. Close #123 -->
Close #30 

## 👀 리뷰어에게 바라는 점
<!-- 코드에서 중점적으로 봐줬으면 하는 부분이나, 궁금한 부분을 자유롭게 작성해주세요 -->
- N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * 일부 서비스 및 저장소 클래스의 트랜잭션 관리 방식을 개선하여 데이터베이스 작업의 안정성과 일관성을 강화했습니다.  
  * 내부 메서드 접근 제한 및 트랜잭션 관련 설정이 변경되었습니다.  
  * 사용자에게 직접적으로 노출되는 기능 변화는 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->