### PR TITLE
[Feat] Transaction Outbox Pattern 적용

### DIFF
--- a/src/main/kotlin/com/yapp/brake/auth/controller/AuthController.kt
+++ b/src/main/kotlin/com/yapp/brake/auth/controller/AuthController.kt
@@ -2,16 +2,13 @@ package com.yapp.brake.auth.controller
 
 import com.yapp.brake.auth.dto.request.LogoutRequest
 import com.yapp.brake.auth.dto.request.OAuthLoginRequest
-import com.yapp.brake.auth.dto.request.OAuthWithdrawRequest
 import com.yapp.brake.auth.dto.request.RefreshTokenRequest
 import com.yapp.brake.auth.dto.response.OAuthLoginResponse
 import com.yapp.brake.auth.dto.response.RefreshTokenResponse
 import com.yapp.brake.auth.service.AuthUseCase
 import com.yapp.brake.common.dto.ApiResponse
-import com.yapp.brake.common.security.getMemberId
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
-import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
@@ -46,14 +43,5 @@ class AuthController(
         request: LogoutRequest,
     ) {
         authUseCase.logout(request.accessToken)
-    }
-
-    @DeleteMapping("/withdraw")
-    @ResponseStatus(HttpStatus.NO_CONTENT)
-    fun withdraw(
-        @RequestBody @Valid
-        request: OAuthWithdrawRequest,
-    ) {
-        authUseCase.withdraw(request.provider, request.authorizationCode ?: getMemberId().toString())
     }
 }

--- a/src/main/kotlin/com/yapp/brake/auth/service/AuthService.kt
+++ b/src/main/kotlin/com/yapp/brake/auth/service/AuthService.kt
@@ -8,8 +8,6 @@ import com.yapp.brake.auth.infrastructure.RefreshTokenRepository
 import com.yapp.brake.common.constants.TOKEN_TYPE_REFRESH
 import com.yapp.brake.common.enums.Role
 import com.yapp.brake.common.enums.SocialProvider
-import com.yapp.brake.common.event.EventType
-import com.yapp.brake.common.event.payload.AuthWithdrawEventPayload
 import com.yapp.brake.common.exception.CustomException
 import com.yapp.brake.common.exception.ErrorCode
 import com.yapp.brake.common.security.getMemberId
@@ -18,7 +16,6 @@ import com.yapp.brake.member.infrastructure.MemberWriter
 import com.yapp.brake.member.model.Member
 import com.yapp.brake.oauth.model.OAuthUserInfo
 import com.yapp.brake.oauth.service.OAuthProvider
-import com.yapp.brake.outbox.infrastructure.event.OutboxEventPublisher
 import org.springframework.stereotype.Service
 import java.time.Duration
 
@@ -30,7 +27,6 @@ class AuthService(
     private val memberWriter: MemberWriter,
     private val refreshTokenRepository: RefreshTokenRepository,
     private val blackListRepository: BlackListRepository,
-    private val outboxEventPublisher: OutboxEventPublisher,
 ) : AuthUseCase {
     override fun login(request: OAuthLoginRequest): OAuthLoginResponse {
         val authProvider =
@@ -76,18 +72,14 @@ class AuthService(
         blackListRepository.add(accessToken, Duration.ofMillis(ttl))
     }
 
+    /***
+     * 삭제 예정
+     */
     override fun withdraw(
         socialProvider: SocialProvider,
         credential: String,
     ) {
-        val authProvider =
-            findProvider(socialProvider)
-                ?: throw CustomException(ErrorCode.BAD_REQUEST)
-
-        authProvider.withdraw(credential)
-
-        val eventPayload = AuthWithdrawEventPayload(getMemberId())
-        outboxEventPublisher.publish(EventType.AUTH_WITHDRAW, eventPayload)
+        TODO("Not yet implemented")
     }
 
     private fun findOrCreateMember(

--- a/src/main/kotlin/com/yapp/brake/auth/service/listener/AuthMemberDeleteEventListener.kt
+++ b/src/main/kotlin/com/yapp/brake/auth/service/listener/AuthMemberDeleteEventListener.kt
@@ -1,0 +1,26 @@
+package com.yapp.brake.auth.service.listener
+
+import com.yapp.brake.common.enums.SocialProvider
+import com.yapp.brake.common.event.payload.MemberDeletedEventPayload
+import com.yapp.brake.common.exception.CustomException
+import com.yapp.brake.common.exception.ErrorCode
+import com.yapp.brake.oauth.service.OAuthProvider
+import org.springframework.context.event.EventListener
+import org.springframework.stereotype.Component
+
+@Component
+class AuthMemberDeleteEventListener(
+    private val oauthProviders: List<OAuthProvider>,
+) {
+    @EventListener
+    fun withdraw(payload: MemberDeletedEventPayload) {
+        val authProvider =
+            findProvider(SocialProvider.from(payload.socialProvider))
+                ?: throw CustomException(ErrorCode.BAD_REQUEST)
+
+        authProvider.withdraw(payload.authId)
+    }
+
+    private fun findProvider(socialType: SocialProvider): OAuthProvider? =
+        oauthProviders.firstOrNull { it.supports(socialType) }
+}

--- a/src/main/kotlin/com/yapp/brake/common/decorator/TaskLoggingDecorator.kt
+++ b/src/main/kotlin/com/yapp/brake/common/decorator/TaskLoggingDecorator.kt
@@ -1,0 +1,19 @@
+package com.yapp.brake.common.decorator
+
+import org.slf4j.MDC
+import org.springframework.core.task.TaskDecorator
+
+class TaskLoggingDecorator : TaskDecorator {
+    override fun decorate(runnable: Runnable): Runnable {
+        val contextMap: Map<String, String> = MDC.getCopyOfContextMap()
+
+        return Runnable {
+            try {
+                MDC.setContextMap(contextMap)
+                runnable.run()
+            } finally {
+                MDC.clear()
+            }
+        }
+    }
+}

--- a/src/main/kotlin/com/yapp/brake/common/event/Event.kt
+++ b/src/main/kotlin/com/yapp/brake/common/event/Event.kt
@@ -1,0 +1,38 @@
+package com.yapp.brake.common.event
+
+import com.yapp.brake.common.serializer.DataSerializer.deserialize
+import com.yapp.brake.common.serializer.DataSerializer.serialize
+
+class Event<T : EventPayload>(
+    val type: EventType,
+    val payload: T,
+) {
+    fun toJson() = serialize(this)
+
+    companion object {
+        fun of(
+            type: EventType,
+            payload: EventPayload,
+        ) = Event(
+            type = type,
+            payload = payload,
+        )
+
+        fun fromJson(json: String?): Event<EventPayload>? {
+            val eventRaw =
+                deserialize(json, EventRaw::class.java)
+                    ?: return null
+
+            val eventType = EventType.from(eventRaw.type)
+            val payloadClass = eventType.payloadClass
+            val payload = deserialize(eventRaw.payload, payloadClass)
+
+            return of(eventType, payload)
+        }
+
+        private data class EventRaw(
+            val type: String,
+            val payload: Any,
+        )
+    }
+}

--- a/src/main/kotlin/com/yapp/brake/common/event/EventPayload.kt
+++ b/src/main/kotlin/com/yapp/brake/common/event/EventPayload.kt
@@ -1,0 +1,3 @@
+package com.yapp.brake.common.event
+
+interface EventPayload

--- a/src/main/kotlin/com/yapp/brake/common/event/EventType.kt
+++ b/src/main/kotlin/com/yapp/brake/common/event/EventType.kt
@@ -1,0 +1,24 @@
+package com.yapp.brake.common.event
+
+import com.yapp.brake.common.event.payload.AuthWithdrawEventPayload
+import io.github.oshai.kotlinlogging.KotlinLogging
+
+private val logger = KotlinLogging.logger { }
+
+enum class EventType(
+    val payloadClass: Class<out EventPayload>,
+) {
+    AUTH_WITHDRAW(AuthWithdrawEventPayload::class.java),
+    ;
+
+    companion object {
+        fun from(type: String): EventType {
+            try {
+                return valueOf(type)
+            } catch (e: Exception) {
+                logger.error(e) { "[EventType.from] type=$type" }
+                throw IllegalArgumentException("Invalid type=$type")
+            }
+        }
+    }
+}

--- a/src/main/kotlin/com/yapp/brake/common/event/EventType.kt
+++ b/src/main/kotlin/com/yapp/brake/common/event/EventType.kt
@@ -1,6 +1,6 @@
 package com.yapp.brake.common.event
 
-import com.yapp.brake.common.event.payload.AuthWithdrawEventPayload
+import com.yapp.brake.common.event.payload.MemberDeletedEventPayload
 import io.github.oshai.kotlinlogging.KotlinLogging
 
 private val logger = KotlinLogging.logger { }
@@ -8,7 +8,7 @@ private val logger = KotlinLogging.logger { }
 enum class EventType(
     val payloadClass: Class<out EventPayload>,
 ) {
-    AUTH_WITHDRAW(AuthWithdrawEventPayload::class.java),
+    MEMBER_DELETED(MemberDeletedEventPayload::class.java),
     ;
 
     companion object {

--- a/src/main/kotlin/com/yapp/brake/common/event/payload/AuthWithdrawEventPayload.kt
+++ b/src/main/kotlin/com/yapp/brake/common/event/payload/AuthWithdrawEventPayload.kt
@@ -1,7 +1,0 @@
-package com.yapp.brake.common.event.payload
-
-import com.yapp.brake.common.event.EventPayload
-
-data class AuthWithdrawEventPayload(
-    val userId: Long,
-) : EventPayload

--- a/src/main/kotlin/com/yapp/brake/common/event/payload/AuthWithdrawEventPayload.kt
+++ b/src/main/kotlin/com/yapp/brake/common/event/payload/AuthWithdrawEventPayload.kt
@@ -1,0 +1,7 @@
+package com.yapp.brake.common.event.payload
+
+import com.yapp.brake.common.event.EventPayload
+
+data class AuthWithdrawEventPayload(
+    val userId: Long,
+) : EventPayload

--- a/src/main/kotlin/com/yapp/brake/common/event/payload/MemberDeletedEventPayload.kt
+++ b/src/main/kotlin/com/yapp/brake/common/event/payload/MemberDeletedEventPayload.kt
@@ -1,0 +1,11 @@
+package com.yapp.brake.common.event.payload
+
+import com.yapp.brake.common.event.EventPayload
+
+data class MemberDeletedEventPayload(
+    val memberId: Long,
+    val socialProvider: String,
+    val authId: String,
+    val authEmail: String,
+    val deviceId: String,
+) : EventPayload

--- a/src/main/kotlin/com/yapp/brake/common/serializer/DataSerializer.kt
+++ b/src/main/kotlin/com/yapp/brake/common/serializer/DataSerializer.kt
@@ -1,0 +1,39 @@
+package com.yapp.brake.common.serializer
+
+import com.fasterxml.jackson.core.JsonProcessingException
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import io.github.oshai.kotlinlogging.KotlinLogging
+
+private val logger = KotlinLogging.logger { }
+
+object DataSerializer {
+    private val objectMapper: ObjectMapper = initialize()
+
+    private fun initialize(): ObjectMapper = jacksonObjectMapper().registerModules(JavaTimeModule())
+
+    fun <T> deserialize(
+        data: String?,
+        clazz: Class<T>,
+    ): T? =
+        try {
+            objectMapper.readValue(data, clazz)
+        } catch (e: JsonProcessingException) {
+            logger.error(e) { "[DataSerializer.deserialize] data=$data, clazz=$clazz" }
+            null
+        }
+
+    fun <T> deserialize(
+        data: Any?,
+        clazz: Class<T>,
+    ): T = objectMapper.convertValue(data, clazz)
+
+    fun serialize(any: Any?): String? =
+        try {
+            objectMapper.writeValueAsString(any)
+        } catch (e: JsonProcessingException) {
+            logger.error(e) { "[DataSerializer.serialize] object=$any" }
+            null
+        }
+}

--- a/src/main/kotlin/com/yapp/brake/member/controller/MemberController.kt
+++ b/src/main/kotlin/com/yapp/brake/member/controller/MemberController.kt
@@ -6,10 +6,13 @@ import com.yapp.brake.member.dto.request.UpdateNicknameRequest
 import com.yapp.brake.member.dto.response.MemberResponse
 import com.yapp.brake.member.service.MemberUseCase
 import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
@@ -25,4 +28,10 @@ class MemberController(
         @Valid @RequestBody
         request: UpdateNicknameRequest,
     ): ApiResponse<MemberResponse> = ApiResponse.success(memberUseCase.update(request.nickname))
+
+    @DeleteMapping("/me")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    fun delete() {
+        memberUseCase.delete(getMemberId())
+    }
 }

--- a/src/main/kotlin/com/yapp/brake/member/service/MemberUseCase.kt
+++ b/src/main/kotlin/com/yapp/brake/member/service/MemberUseCase.kt
@@ -6,4 +6,6 @@ interface MemberUseCase {
     fun getMember(memberId: Long): MemberResponse
 
     fun update(nickname: String): MemberResponse
+
+    fun delete(memberId: Long)
 }

--- a/src/main/kotlin/com/yapp/brake/oauth/service/kakao/KakaoAuthProvider.kt
+++ b/src/main/kotlin/com/yapp/brake/oauth/service/kakao/KakaoAuthProvider.kt
@@ -1,7 +1,6 @@
 package com.yapp.brake.oauth.service.kakao
 
 import com.yapp.brake.common.enums.SocialProvider
-import com.yapp.brake.member.infrastructure.MemberReader
 import com.yapp.brake.oauth.infrastructure.feign.kakao.KakaoApiFeignClient
 import com.yapp.brake.oauth.infrastructure.feign.kakao.KakaoAuthFeignClient
 import com.yapp.brake.oauth.infrastructure.feign.kakao.response.KakaoUserInfoResponse
@@ -17,7 +16,6 @@ class KakaoAuthProvider(
     private val kakaoProperties: KakaoProperties,
     private val kakaoAuthFeignClient: KakaoAuthFeignClient,
     private val kakaoApiFeignClient: KakaoApiFeignClient,
-    private val memberReader: MemberReader,
 ) : OAuthProvider {
     override fun getAccessToken(code: String): String {
         return try {
@@ -52,12 +50,10 @@ class KakaoAuthProvider(
 
     override fun withdraw(credential: String) {
         try {
-            val member = memberReader.getById(credential.toLong())
-
             kakaoApiFeignClient.unlink(
                 adminKey = "$KAKAO_UNLINK_HEADER_PREFIX${kakaoProperties.adminKey}",
                 targetIdType = KAKAO_UNLINK_TARGET_ID_TYPE,
-                targetId = member.oAuthUserInfo.id.toLong(),
+                targetId = credential.toLong(),
             )
         } catch (e: Exception) {
             logger.error(e) { "[KakaoAuthProvider.withdraw] code=$credential" }

--- a/src/main/kotlin/com/yapp/brake/oauth/service/kakao/KakaoAuthProvider.kt
+++ b/src/main/kotlin/com/yapp/brake/oauth/service/kakao/KakaoAuthProvider.kt
@@ -55,7 +55,7 @@ class KakaoAuthProvider(
             val member = memberReader.getById(credential.toLong())
 
             kakaoApiFeignClient.unlink(
-                adminKey = "$KAKAO_UNLINK_HEADER_PREFIX${kakaoProperties.clientId}",
+                adminKey = "$KAKAO_UNLINK_HEADER_PREFIX${kakaoProperties.adminKey}",
                 targetIdType = KAKAO_UNLINK_TARGET_ID_TYPE,
                 targetId = member.oAuthUserInfo.id.toLong(),
             )
@@ -70,6 +70,6 @@ class KakaoAuthProvider(
         private const val KAKAO_AUTH_GRANT_TYPE = "authorization_code"
         private const val KAKAO_AUTH_HEADER_PREFIX = "Bearer "
         private const val KAKAO_UNLINK_HEADER_PREFIX = "KakaoAK "
-        private const val KAKAO_UNLINK_TARGET_ID_TYPE = "user_id "
+        private const val KAKAO_UNLINK_TARGET_ID_TYPE = "user_id"
     }
 }

--- a/src/main/kotlin/com/yapp/brake/oauth/service/kakao/KakaoProperties.kt
+++ b/src/main/kotlin/com/yapp/brake/oauth/service/kakao/KakaoProperties.kt
@@ -8,4 +8,5 @@ import org.springframework.stereotype.Component
 data class KakaoProperties(
     var clientId: String = "",
     var redirectUri: String = "",
+    var adminKey: String = "",
 )

--- a/src/main/kotlin/com/yapp/brake/oauth/service/listener/OAuthMemberDeleteEventListener.kt
+++ b/src/main/kotlin/com/yapp/brake/oauth/service/listener/OAuthMemberDeleteEventListener.kt
@@ -1,4 +1,4 @@
-package com.yapp.brake.auth.service.listener
+package com.yapp.brake.oauth.service.listener
 
 import com.yapp.brake.common.enums.SocialProvider
 import com.yapp.brake.common.event.payload.MemberDeletedEventPayload
@@ -9,7 +9,7 @@ import org.springframework.context.event.EventListener
 import org.springframework.stereotype.Component
 
 @Component
-class AuthMemberDeleteEventListener(
+class OAuthMemberDeleteEventListener(
     private val oauthProviders: List<OAuthProvider>,
 ) {
     @EventListener

--- a/src/main/kotlin/com/yapp/brake/outbox/infrastructure/OutboxReader.kt
+++ b/src/main/kotlin/com/yapp/brake/outbox/infrastructure/OutboxReader.kt
@@ -1,0 +1,7 @@
+package com.yapp.brake.outbox.infrastructure
+
+import com.yapp.brake.outbox.model.Outbox
+
+interface OutboxReader {
+    fun findAll(pageSize: Int): List<Outbox>
+}

--- a/src/main/kotlin/com/yapp/brake/outbox/infrastructure/OutboxWriter.kt
+++ b/src/main/kotlin/com/yapp/brake/outbox/infrastructure/OutboxWriter.kt
@@ -1,0 +1,9 @@
+package com.yapp.brake.outbox.infrastructure
+
+import com.yapp.brake.outbox.model.Outbox
+
+interface OutboxWriter {
+    fun save(outbox: Outbox)
+
+    fun delete(outbox: Outbox)
+}

--- a/src/main/kotlin/com/yapp/brake/outbox/infrastructure/event/OutboxEventPublisher.kt
+++ b/src/main/kotlin/com/yapp/brake/outbox/infrastructure/event/OutboxEventPublisher.kt
@@ -16,11 +16,11 @@ class OutboxEventPublisher(
         type: EventType,
         payload: EventPayload,
     ) {
-        val payload =
+        val event =
             Event.of(type, payload)
                 .toJson() ?: throw IllegalStateException("serialize fail")
 
-        val outbox = Outbox.create(type, payload)
+        val outbox = Outbox.create(type, event)
 
         applicationEventPublisher.publishEvent(OutboxEvent.of(outbox))
     }

--- a/src/main/kotlin/com/yapp/brake/outbox/infrastructure/event/OutboxEventPublisher.kt
+++ b/src/main/kotlin/com/yapp/brake/outbox/infrastructure/event/OutboxEventPublisher.kt
@@ -1,0 +1,27 @@
+package com.yapp.brake.outbox.infrastructure.event
+
+import com.yapp.brake.common.event.Event
+import com.yapp.brake.common.event.EventPayload
+import com.yapp.brake.common.event.EventType
+import com.yapp.brake.outbox.model.Outbox
+import com.yapp.brake.outbox.model.OutboxEvent
+import org.springframework.context.ApplicationEventPublisher
+import org.springframework.stereotype.Component
+
+@Component
+class OutboxEventPublisher(
+    private val applicationEventPublisher: ApplicationEventPublisher,
+) {
+    fun publish(
+        type: EventType,
+        payload: EventPayload,
+    ) {
+        val payload =
+            Event.of(type, payload)
+                .toJson() ?: throw IllegalStateException("serialize fail")
+
+        val outbox = Outbox.create(type, payload)
+
+        applicationEventPublisher.publishEvent(OutboxEvent.of(outbox))
+    }
+}

--- a/src/main/kotlin/com/yapp/brake/outbox/infrastructure/jpa/OutboxEntity.kt
+++ b/src/main/kotlin/com/yapp/brake/outbox/infrastructure/jpa/OutboxEntity.kt
@@ -33,7 +33,7 @@ class OutboxEntity(
                 outboxId = outbox.outboxId,
                 eventType = outbox.eventType,
                 payload = outbox.payload,
-                createdAt = LocalDateTime.now(),
+                createdAt = outbox.createdAt,
             )
     }
 }

--- a/src/main/kotlin/com/yapp/brake/outbox/infrastructure/jpa/OutboxEntity.kt
+++ b/src/main/kotlin/com/yapp/brake/outbox/infrastructure/jpa/OutboxEntity.kt
@@ -5,8 +5,6 @@ import com.yapp.brake.outbox.model.Outbox
 import jakarta.persistence.Entity
 import jakarta.persistence.EnumType
 import jakarta.persistence.Enumerated
-import jakarta.persistence.GeneratedValue
-import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
 import jakarta.persistence.Table
 import java.time.LocalDateTime
@@ -15,8 +13,7 @@ import java.time.LocalDateTime
 @Entity
 class OutboxEntity(
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    val outboxId: Long = 0L,
+    val outboxId: String,
     @Enumerated(EnumType.STRING)
     val eventType: EventType,
     val payload: String,

--- a/src/main/kotlin/com/yapp/brake/outbox/infrastructure/jpa/OutboxEntity.kt
+++ b/src/main/kotlin/com/yapp/brake/outbox/infrastructure/jpa/OutboxEntity.kt
@@ -1,0 +1,42 @@
+package com.yapp.brake.outbox.infrastructure.jpa
+
+import com.yapp.brake.common.event.EventType
+import com.yapp.brake.outbox.model.Outbox
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import java.time.LocalDateTime
+
+@Table(name = "outbox")
+@Entity
+class OutboxEntity(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val outboxId: Long = 0L,
+    @Enumerated(EnumType.STRING)
+    val eventType: EventType,
+    val payload: String,
+    val createdAt: LocalDateTime,
+) {
+    fun toDomain() =
+        Outbox(
+            outboxId = outboxId,
+            eventType = eventType,
+            payload = payload,
+            createdAt = createdAt,
+        )
+
+    companion object {
+        fun from(outbox: Outbox) =
+            OutboxEntity(
+                outboxId = outbox.outboxId,
+                eventType = outbox.eventType,
+                payload = outbox.payload,
+                createdAt = LocalDateTime.now(),
+            )
+    }
+}

--- a/src/main/kotlin/com/yapp/brake/outbox/infrastructure/jpa/OutboxJpaReader.kt
+++ b/src/main/kotlin/com/yapp/brake/outbox/infrastructure/jpa/OutboxJpaReader.kt
@@ -1,0 +1,18 @@
+package com.yapp.brake.outbox.infrastructure.jpa
+
+import com.yapp.brake.outbox.infrastructure.OutboxReader
+import com.yapp.brake.outbox.model.Outbox
+import org.springframework.data.domain.Pageable
+import org.springframework.stereotype.Repository
+import org.springframework.transaction.annotation.Transactional
+
+@Repository
+@Transactional(readOnly = true)
+class OutboxJpaReader(
+    private val outboxRepository: OutboxRepository,
+) : OutboxReader {
+    override fun findAll(pageSize: Int): List<Outbox> {
+        val pageable = Pageable.ofSize(pageSize)
+        return outboxRepository.findAllByOutboxIdAsc(pageable).map { it.toDomain() }
+    }
+}

--- a/src/main/kotlin/com/yapp/brake/outbox/infrastructure/jpa/OutboxJpaReader.kt
+++ b/src/main/kotlin/com/yapp/brake/outbox/infrastructure/jpa/OutboxJpaReader.kt
@@ -13,6 +13,6 @@ class OutboxJpaReader(
 ) : OutboxReader {
     override fun findAll(pageSize: Int): List<Outbox> {
         val pageable = Pageable.ofSize(pageSize)
-        return outboxRepository.findAllByOrderByOutboxIdAsc(pageable).map { it.toDomain() }
+        return outboxRepository.findAllByOrderByCreatedAtAsc(pageable).map { it.toDomain() }
     }
 }

--- a/src/main/kotlin/com/yapp/brake/outbox/infrastructure/jpa/OutboxJpaReader.kt
+++ b/src/main/kotlin/com/yapp/brake/outbox/infrastructure/jpa/OutboxJpaReader.kt
@@ -13,6 +13,6 @@ class OutboxJpaReader(
 ) : OutboxReader {
     override fun findAll(pageSize: Int): List<Outbox> {
         val pageable = Pageable.ofSize(pageSize)
-        return outboxRepository.findAllByOutboxIdAsc(pageable).map { it.toDomain() }
+        return outboxRepository.findAllByOrderByOutboxIdAsc(pageable).map { it.toDomain() }
     }
 }

--- a/src/main/kotlin/com/yapp/brake/outbox/infrastructure/jpa/OutboxJpaWriter.kt
+++ b/src/main/kotlin/com/yapp/brake/outbox/infrastructure/jpa/OutboxJpaWriter.kt
@@ -1,0 +1,21 @@
+package com.yapp.brake.outbox.infrastructure.jpa
+
+import com.yapp.brake.outbox.infrastructure.OutboxWriter
+import com.yapp.brake.outbox.model.Outbox
+import org.springframework.stereotype.Repository
+import org.springframework.transaction.annotation.Transactional
+
+@Repository
+@Transactional
+class OutboxJpaWriter(
+    private val outboxRepository: OutboxRepository,
+) : OutboxWriter {
+    override fun save(outbox: Outbox) {
+        val entity = OutboxEntity.from(outbox)
+        outboxRepository.save(entity)
+    }
+
+    override fun delete(outbox: Outbox) {
+        outboxRepository.delete(OutboxEntity.from(outbox))
+    }
+}

--- a/src/main/kotlin/com/yapp/brake/outbox/infrastructure/jpa/OutboxRepository.kt
+++ b/src/main/kotlin/com/yapp/brake/outbox/infrastructure/jpa/OutboxRepository.kt
@@ -4,5 +4,5 @@ import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface OutboxRepository : JpaRepository<OutboxEntity, Long> {
-    fun findAllByOrderByOutboxIdAsc(page: Pageable): List<OutboxEntity>
+    fun findAllByOrderByCreatedAtAsc(page: Pageable): List<OutboxEntity>
 }

--- a/src/main/kotlin/com/yapp/brake/outbox/infrastructure/jpa/OutboxRepository.kt
+++ b/src/main/kotlin/com/yapp/brake/outbox/infrastructure/jpa/OutboxRepository.kt
@@ -1,0 +1,8 @@
+package com.yapp.brake.outbox.infrastructure.jpa
+
+import org.springframework.data.domain.Pageable
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface OutboxRepository : JpaRepository<OutboxEntity, Long> {
+    fun findAllByOutboxIdAsc(page: Pageable): List<OutboxEntity>
+}

--- a/src/main/kotlin/com/yapp/brake/outbox/infrastructure/jpa/OutboxRepository.kt
+++ b/src/main/kotlin/com/yapp/brake/outbox/infrastructure/jpa/OutboxRepository.kt
@@ -4,5 +4,5 @@ import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface OutboxRepository : JpaRepository<OutboxEntity, Long> {
-    fun findAllByOutboxIdAsc(page: Pageable): List<OutboxEntity>
+    fun findAllByOrderByOutboxIdAsc(page: Pageable): List<OutboxEntity>
 }

--- a/src/main/kotlin/com/yapp/brake/outbox/model/Outbox.kt
+++ b/src/main/kotlin/com/yapp/brake/outbox/model/Outbox.kt
@@ -2,9 +2,10 @@ package com.yapp.brake.outbox.model
 
 import com.yapp.brake.common.event.EventType
 import java.time.LocalDateTime
+import java.util.UUID
 
 data class Outbox(
-    val outboxId: Long = 0L,
+    val outboxId: String,
     val eventType: EventType,
     val payload: String,
     val createdAt: LocalDateTime? = null,
@@ -14,6 +15,7 @@ data class Outbox(
             eventType: EventType,
             payload: String,
         ) = Outbox(
+            outboxId = UUID.randomUUID().toString(),
             eventType = eventType,
             payload = payload,
         )

--- a/src/main/kotlin/com/yapp/brake/outbox/model/Outbox.kt
+++ b/src/main/kotlin/com/yapp/brake/outbox/model/Outbox.kt
@@ -8,7 +8,7 @@ data class Outbox(
     val outboxId: String,
     val eventType: EventType,
     val payload: String,
-    val createdAt: LocalDateTime? = null,
+    val createdAt: LocalDateTime,
 ) {
     companion object {
         fun create(
@@ -18,6 +18,7 @@ data class Outbox(
             outboxId = UUID.randomUUID().toString(),
             eventType = eventType,
             payload = payload,
+            createdAt = LocalDateTime.now(),
         )
     }
 }

--- a/src/main/kotlin/com/yapp/brake/outbox/model/Outbox.kt
+++ b/src/main/kotlin/com/yapp/brake/outbox/model/Outbox.kt
@@ -1,0 +1,21 @@
+package com.yapp.brake.outbox.model
+
+import com.yapp.brake.common.event.EventType
+import java.time.LocalDateTime
+
+data class Outbox(
+    val outboxId: Long = 0L,
+    val eventType: EventType,
+    val payload: String,
+    val createdAt: LocalDateTime? = null,
+) {
+    companion object {
+        fun create(
+            eventType: EventType,
+            payload: String,
+        ) = Outbox(
+            eventType = eventType,
+            payload = payload,
+        )
+    }
+}

--- a/src/main/kotlin/com/yapp/brake/outbox/model/OutboxEvent.kt
+++ b/src/main/kotlin/com/yapp/brake/outbox/model/OutboxEvent.kt
@@ -1,0 +1,9 @@
+package com.yapp.brake.outbox.model
+
+data class OutboxEvent(
+    val outbox: Outbox,
+) {
+    companion object {
+        fun of(outbox: Outbox) = OutboxEvent(outbox)
+    }
+}

--- a/src/main/kotlin/com/yapp/brake/outbox/service/MessageRelay.kt
+++ b/src/main/kotlin/com/yapp/brake/outbox/service/MessageRelay.kt
@@ -1,0 +1,63 @@
+package com.yapp.brake.outbox.service
+
+import com.yapp.brake.common.event.Event
+import com.yapp.brake.outbox.infrastructure.OutboxReader
+import com.yapp.brake.outbox.infrastructure.OutboxWriter
+import com.yapp.brake.outbox.model.Outbox
+import com.yapp.brake.outbox.model.OutboxEvent
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.springframework.context.ApplicationEventPublisher
+import org.springframework.scheduling.annotation.Async
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+import org.springframework.transaction.event.TransactionPhase
+import org.springframework.transaction.event.TransactionalEventListener
+import java.util.concurrent.TimeUnit
+
+private val logger = KotlinLogging.logger { }
+
+@Component
+class MessageRelay(
+    private val outboxReader: OutboxReader,
+    private val outboxWriter: OutboxWriter,
+    private val applicationEventPublisher: ApplicationEventPublisher,
+) {
+    @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
+    fun createOutbox(outboxEvent: OutboxEvent) {
+        logger.info { "[MessageRelay.createOutbox] outboxEvent=$outboxEvent" }
+        outboxWriter.save(outboxEvent.outbox)
+    }
+
+    @Async("messageRelayPublishEventExecutor")
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    fun publishEvent(outboxEvent: OutboxEvent) {
+        publishEvent(outboxEvent.outbox)
+    }
+
+    @Scheduled(
+        fixedDelay = 10,
+        initialDelay = 5,
+        timeUnit = TimeUnit.SECONDS,
+        scheduler = "messageRelayPublishPendingEventExecutor",
+    )
+    fun publishPendingEvent() {
+        val outboxes = outboxReader.findAll(OUTBOX_RETRY_SIZE)
+        outboxes.forEach { publishEvent(it) }
+    }
+
+    private fun publishEvent(outbox: Outbox) {
+        try {
+            val event = Event.fromJson(outbox.payload) ?: return
+
+            applicationEventPublisher.publishEvent(event.payload)
+
+            outboxWriter.delete(outbox)
+        } catch (e: Exception) {
+            logger.error(e) { "[MessageRelay.publishEvent] outbox=$outbox" }
+        }
+    }
+
+    companion object {
+        private const val OUTBOX_RETRY_SIZE = 100
+    }
+}

--- a/src/main/kotlin/com/yapp/brake/outbox/service/MessageRelayConfig.kt
+++ b/src/main/kotlin/com/yapp/brake/outbox/service/MessageRelayConfig.kt
@@ -1,0 +1,26 @@
+package com.yapp.brake.outbox.service
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.scheduling.annotation.EnableAsync
+import org.springframework.scheduling.annotation.EnableScheduling
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor
+import java.util.concurrent.Executor
+import java.util.concurrent.Executors
+
+@EnableAsync
+@Configuration
+@EnableScheduling
+class MessageRelayConfig {
+    fun messageRelayPublishEventExecutor(): Executor =
+        ThreadPoolTaskExecutor()
+            .apply {
+                corePoolSize = 20
+                maxPoolSize = 50
+                queueCapacity = 100
+                setThreadNamePrefix("pub-event-")
+            }
+
+    @Bean
+    fun messageRelayPublishPendingEventExecutor(): Executor = Executors.newSingleThreadScheduledExecutor()
+}

--- a/src/main/kotlin/com/yapp/brake/outbox/service/listener/MessageRelay.kt
+++ b/src/main/kotlin/com/yapp/brake/outbox/service/listener/MessageRelay.kt
@@ -1,4 +1,4 @@
-package com.yapp.brake.outbox.service
+package com.yapp.brake.outbox.service.listener
 
 import com.yapp.brake.common.event.Event
 import com.yapp.brake.outbox.infrastructure.OutboxReader
@@ -50,7 +50,6 @@ class MessageRelay(
             val event = Event.fromJson(outbox.payload) ?: return
 
             applicationEventPublisher.publishEvent(event.payload)
-
             outboxWriter.delete(outbox)
         } catch (e: Exception) {
             logger.error(e) { "[MessageRelay.publishEvent] outbox=$outbox" }

--- a/src/main/kotlin/com/yapp/brake/outbox/service/listener/MessageRelayConfig.kt
+++ b/src/main/kotlin/com/yapp/brake/outbox/service/listener/MessageRelayConfig.kt
@@ -1,4 +1,4 @@
-package com.yapp.brake.outbox.service
+package com.yapp.brake.outbox.service.listener
 
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -12,6 +12,7 @@ import java.util.concurrent.Executors
 @Configuration
 @EnableScheduling
 class MessageRelayConfig {
+    @Bean
     fun messageRelayPublishEventExecutor(): Executor =
         ThreadPoolTaskExecutor()
             .apply {

--- a/src/main/kotlin/com/yapp/brake/outbox/service/listener/MessageRelayConfig.kt
+++ b/src/main/kotlin/com/yapp/brake/outbox/service/listener/MessageRelayConfig.kt
@@ -7,6 +7,7 @@ import org.springframework.scheduling.annotation.EnableScheduling
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor
 import java.util.concurrent.Executor
 import java.util.concurrent.Executors
+import java.util.concurrent.ThreadPoolExecutor.CallerRunsPolicy
 
 @EnableAsync
 @Configuration
@@ -16,12 +17,22 @@ class MessageRelayConfig {
     fun messageRelayPublishEventExecutor(): Executor =
         ThreadPoolTaskExecutor()
             .apply {
-                corePoolSize = 20
-                maxPoolSize = 50
-                queueCapacity = 100
+                corePoolSize = POOL_SIZE
+                maxPoolSize = MAX_POOL_SIZE
+                queueCapacity = QUEUE_SIZE
                 setThreadNamePrefix("pub-event-")
+                setWaitForTasksToCompleteOnShutdown(true)
+                setAwaitTerminationSeconds(AWAIT_TERMINATION_SECONDS)
+                setRejectedExecutionHandler(CallerRunsPolicy())
             }
 
     @Bean
     fun messageRelayPublishPendingEventExecutor(): Executor = Executors.newSingleThreadScheduledExecutor()
+
+    companion object {
+        private const val POOL_SIZE = 20
+        private const val MAX_POOL_SIZE = 50
+        private const val QUEUE_SIZE = 100
+        private const val AWAIT_TERMINATION_SECONDS = 10
+    }
 }

--- a/src/main/kotlin/com/yapp/brake/outbox/service/listener/MessageRelayConfig.kt
+++ b/src/main/kotlin/com/yapp/brake/outbox/service/listener/MessageRelayConfig.kt
@@ -1,5 +1,6 @@
 package com.yapp.brake.outbox.service.listener
 
+import com.yapp.brake.common.decorator.TaskLoggingDecorator
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.scheduling.annotation.EnableAsync
@@ -24,6 +25,7 @@ class MessageRelayConfig {
                 setWaitForTasksToCompleteOnShutdown(true)
                 setAwaitTerminationSeconds(AWAIT_TERMINATION_SECONDS)
                 setRejectedExecutionHandler(CallerRunsPolicy())
+                setTaskDecorator(TaskLoggingDecorator())
             }
 
     @Bean

--- a/src/main/resources/db/migration/V2__create_outbox.sql
+++ b/src/main/resources/db/migration/V2__create_outbox.sql
@@ -1,0 +1,9 @@
+CREATE TABLE outbox (
+    outbox_id   BIGINT        NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    event_type  VARCHAR(100)  NOT NULL,
+    payload     VARCHAR(5000) NOT NULL,
+    created_at  DATETIME      NOT NULL
+);
+
+ALTER TABLE `member`
+ADD CONSTRAINT uk_member_device_id UNIQUE (`device_id`);

--- a/src/main/resources/db/migration/V2__create_outbox.sql
+++ b/src/main/resources/db/migration/V2__create_outbox.sql
@@ -1,9 +1,11 @@
 CREATE TABLE outbox (
-    outbox_id   BIGINT        NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    outbox_id   CHAR(36)     NOT NULL PRIMARY KEY,
     event_type  VARCHAR(100)  NOT NULL,
     payload     VARCHAR(5000) NOT NULL,
     created_at  DATETIME      NOT NULL
 );
+
+CREATE INDEX idx_outbox_created_at ON outbox (created_at);
 
 ALTER TABLE `member`
 ADD CONSTRAINT uk_member_device_id UNIQUE (`device_id`);

--- a/src/test/kotlin/com/yapp/brake/auth/controller/AuthControllerTest.kt
+++ b/src/test/kotlin/com/yapp/brake/auth/controller/AuthControllerTest.kt
@@ -3,7 +3,6 @@ package com.yapp.brake.auth.controller
 import andDocument
 import com.yapp.brake.auth.dto.request.LogoutRequest
 import com.yapp.brake.auth.dto.request.OAuthLoginRequest
-import com.yapp.brake.auth.dto.request.OAuthWithdrawRequest
 import com.yapp.brake.auth.dto.request.RefreshTokenRequest
 import com.yapp.brake.auth.dto.response.OAuthLoginResponse
 import com.yapp.brake.auth.dto.response.RefreshTokenResponse
@@ -122,29 +121,6 @@ class AuthControllerTest : RestApiTestBase() {
                 Tag.AUTH,
                 requestBody(
                     "accessToken" type STRING means "기존 액세스 토큰",
-                ),
-            )
-    }
-
-    @Test
-    fun `탈퇴 API`() {
-        val request = OAuthWithdrawRequest(SocialProvider.KAKAO, "credential")
-
-        doNothing().`when`(authUseCase).withdraw(request.provider, request.authorizationCode!!)
-
-        val builder =
-            RestDocumentationRequestBuilders.delete("/v1/auth/withdraw")
-                .content(request.toJsonString())
-                .contentType(MediaType.APPLICATION_JSON)
-
-        mockMvc.perform(builder)
-            .andExpect(status().isNoContent)
-            .andDocument(
-                "auth-revoke",
-                Tag.AUTH,
-                requestBody(
-                    "provider" type STRING means "소셜 로그인 타입",
-                    "authorizationCode" type STRING means "인가 정보",
                 ),
             )
     }

--- a/src/test/kotlin/com/yapp/brake/auth/service/AuthServiceTest.kt
+++ b/src/test/kotlin/com/yapp/brake/auth/service/AuthServiceTest.kt
@@ -166,24 +166,4 @@ class AuthServiceTest {
 
         SecurityContextHolder.clearContext()
     }
-
-    @Test
-    fun `signOut은 OAuthProvider에 탈퇴 요청을 하고 유저를 삭제한다`() {
-        // given
-        val credential = "valid-credential"
-        val socialProvider = SocialProvider.KAKAO
-        val memberId = 1L
-
-        val authentication = UsernamePasswordAuthenticationToken(memberId.toString(), null)
-        SecurityContextHolder.getContext().authentication = authentication
-
-        // when
-        authService.withdraw(socialProvider, credential)
-
-        // then
-        verify(mockProvider).withdraw(credential)
-        verify(memberWriter).delete(memberId)
-
-        SecurityContextHolder.clearContext()
-    }
 }

--- a/src/test/kotlin/com/yapp/brake/common/event/EventTest.kt
+++ b/src/test/kotlin/com/yapp/brake/common/event/EventTest.kt
@@ -1,0 +1,25 @@
+package com.yapp.brake.common.event
+
+import com.yapp.brake.common.event.payload.AuthWithdrawEventPayload
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class EventTest {
+    @Test
+    fun `직렬화, 역직렬화 테스트`() {
+        val payload = AuthWithdrawEventPayload(userId = 123456L)
+        val event = Event.of(EventType.AUTH_WITHDRAW, payload)
+        val json = event.toJson()
+
+        // println("json = $json")
+
+        val result = Event.fromJson(json)
+
+        assertThat(result!!.type).isEqualTo(event.type)
+        assertThat(result.payload).isInstanceOf(payload::class.java)
+
+        val resultPayload = result.payload as AuthWithdrawEventPayload
+
+        assertThat(resultPayload.userId).isEqualTo(payload.userId)
+    }
+}

--- a/src/test/kotlin/com/yapp/brake/common/event/EventTest.kt
+++ b/src/test/kotlin/com/yapp/brake/common/event/EventTest.kt
@@ -1,14 +1,24 @@
 package com.yapp.brake.common.event
 
-import com.yapp.brake.common.event.payload.AuthWithdrawEventPayload
+import com.yapp.brake.common.enums.SocialProvider
+import com.yapp.brake.common.event.payload.MemberDeletedEventPayload
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import java.util.UUID
 
 class EventTest {
     @Test
     fun `직렬화, 역직렬화 테스트`() {
-        val payload = AuthWithdrawEventPayload(userId = 123456L)
-        val event = Event.of(EventType.AUTH_WITHDRAW, payload)
+        val payload =
+            MemberDeletedEventPayload(
+                memberId = 12345L,
+                socialProvider = SocialProvider.KAKAO.name,
+                authId = "123124",
+                authEmail = "auth@kakao.com",
+                deviceId = UUID.randomUUID().toString(),
+            )
+
+        val event = Event.of(EventType.MEMBER_DELETED, payload)
         val json = event.toJson()
 
         // println("json = $json")
@@ -18,8 +28,8 @@ class EventTest {
         assertThat(result!!.type).isEqualTo(event.type)
         assertThat(result.payload).isInstanceOf(payload::class.java)
 
-        val resultPayload = result.payload as AuthWithdrawEventPayload
+        val resultPayload = result.payload as MemberDeletedEventPayload
 
-        assertThat(resultPayload.userId).isEqualTo(payload.userId)
+        assertThat(resultPayload).isEqualTo(payload)
     }
 }

--- a/src/test/kotlin/com/yapp/brake/member/controller/MemberControllerTest.kt
+++ b/src/test/kotlin/com/yapp/brake/member/controller/MemberControllerTest.kt
@@ -14,6 +14,7 @@ import com.yapp.brake.support.restdocs.toJsonString
 import com.yapp.brake.support.restdocs.type
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito.`when`
+import org.mockito.kotlin.doNothing
 import org.springframework.http.MediaType
 import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
@@ -94,5 +95,26 @@ class MemberControllerTest : RestApiTestBase() {
                     "code" type NUMBER means "HTTP 코드",
                 ),
             )
+    }
+
+    @Test
+    fun `탈퇴 API`() {
+        val memberId = 1L
+        val authentication = UsernamePasswordAuthenticationToken(memberId.toString(), null)
+        SecurityContextHolder.getContext().authentication = authentication
+
+        doNothing().`when`(memberUseCase).delete(memberId)
+
+        val builder =
+            RestDocumentationRequestBuilders.delete("/v1/members/me")
+
+        mockMvc.perform(builder)
+            .andExpect(status().isNoContent)
+            .andDocument(
+                "member-delete",
+                Tag.MEMBER,
+            )
+
+        SecurityContextHolder.clearContext()
     }
 }

--- a/src/test/kotlin/com/yapp/brake/member/service/MemberServiceTest.kt
+++ b/src/test/kotlin/com/yapp/brake/member/service/MemberServiceTest.kt
@@ -1,10 +1,13 @@
 package com.yapp.brake.member.service
 
+import com.yapp.brake.common.event.EventType
+import com.yapp.brake.common.event.payload.MemberDeletedEventPayload
 import com.yapp.brake.common.exception.CustomException
 import com.yapp.brake.common.exception.ErrorCode
 import com.yapp.brake.member.infrastructure.MemberReader
 import com.yapp.brake.member.infrastructure.MemberWriter
 import com.yapp.brake.member.model.MemberState
+import com.yapp.brake.outbox.infrastructure.event.OutboxEventPublisher
 import com.yapp.brake.support.fixture.model.memberFixture
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
@@ -12,6 +15,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.mockito.Mockito.mock
 import org.mockito.kotlin.any
+import org.mockito.kotlin.doNothing
 import org.mockito.kotlin.whenever
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
 import org.springframework.security.core.context.SecurityContextHolder
@@ -19,7 +23,8 @@ import org.springframework.security.core.context.SecurityContextHolder
 class MemberServiceTest {
     private val memberReader = mock<MemberReader>()
     private val memberWriter = mock<MemberWriter>()
-    private val memberService = MemberService(memberReader, memberWriter)
+    private val outboxEventPublisher = mock<OutboxEventPublisher>()
+    private val memberService = MemberService(memberReader, memberWriter, outboxEventPublisher)
 
     @Nested
     inner class GetMemberTest {
@@ -67,5 +72,23 @@ class MemberServiceTest {
         assertThat(result.state).isEqualTo(MemberState.ACTIVE.name)
 
         SecurityContextHolder.clearContext()
+    }
+
+    @Test
+    fun `delete()는 유저 삭제하고 이벤트를 발행한다`() {
+        val member = memberFixture(id = 1L, nickname = "brake-user", state = MemberState.HOLD)
+        val payload =
+            MemberDeletedEventPayload(
+                memberId = member.id,
+                socialProvider = member.oAuthUserInfo.socialProvider.name,
+                authId = member.oAuthUserInfo.id,
+                authEmail = member.oAuthUserInfo.email,
+                deviceId = member.deviceId,
+            )
+        whenever(memberReader.getById(memberId = member.id)).thenReturn(member)
+        doNothing().whenever(memberWriter).delete(member.id)
+        doNothing().whenever(outboxEventPublisher).publish(EventType.MEMBER_DELETED, payload)
+
+        memberService.delete(member.id)
     }
 }

--- a/src/test/kotlin/com/yapp/brake/oauth/service/kakao/KakaoAuthProviderTest.kt
+++ b/src/test/kotlin/com/yapp/brake/oauth/service/kakao/KakaoAuthProviderTest.kt
@@ -1,15 +1,11 @@
 package com.yapp.brake.oauth.service.kakao
 
-import com.yapp.brake.member.infrastructure.MemberReader
 import com.yapp.brake.oauth.infrastructure.feign.kakao.KakaoApiFeignClient
 import com.yapp.brake.oauth.infrastructure.feign.kakao.KakaoAuthFeignClient
 import com.yapp.brake.oauth.infrastructure.feign.kakao.response.KakaoTokenResponse
-import com.yapp.brake.oauth.infrastructure.feign.kakao.response.KakaoUnlinkResponse
 import com.yapp.brake.oauth.infrastructure.feign.kakao.response.KakaoUserInfoResponse
-import com.yapp.brake.support.fixture.model.memberFixture
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertDoesNotThrow
 import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
@@ -18,14 +14,12 @@ class KakaoAuthProviderTest {
     private val kakaoProperties = mock<KakaoProperties>()
     private val kakaoAuthFeignClient = mock<KakaoAuthFeignClient>()
     private val kakaoApiFeignClient = mock<KakaoApiFeignClient>()
-    private val memberReader = mock<MemberReader>()
 
     private val kakaoAuthProvider =
         KakaoAuthProvider(
             kakaoProperties,
             kakaoAuthFeignClient,
             kakaoApiFeignClient,
-            memberReader,
         )
 
     @Test
@@ -70,24 +64,5 @@ class KakaoAuthProviderTest {
 
         assertThat(result.id).isEqualTo(expected.id)
         assertThat(result.email).isEqualTo(expected.kakaoAccount.email)
-    }
-
-    @Test
-    fun `탈퇴를 위해 연결을 끊는다`() {
-        val credential = "12345"
-        val member = memberFixture(id = credential.toLong())
-        whenever(memberReader.getById(credential.toLong())).thenReturn(member)
-
-        whenever(
-            kakaoApiFeignClient.unlink(
-                "adminKey",
-                "tagetIdType",
-                member.oAuthUserInfo.id.toLong(),
-            ),
-        ).thenReturn(
-            KakaoUnlinkResponse(123L),
-        )
-
-        assertDoesNotThrow { kakaoAuthProvider.withdraw(credential) }
     }
 }


### PR DESCRIPTION
## 🔍 반영 내용
<!-- 이번 PR에서 작업한 내용을 간단히 설명해주세요 -->
EventListner 사용 시 DB 트랜잭션과 동기화를 하기 위해 Outbox 패턴을 적용했습니다.

Outbox를 저장하기 위해 테이블을 추가했고 이벤트를 직렬화 역직렬화 하기 위한 DataSerializer.kt를 추가했습니다.

이벤트 발행시 해당 이벤트를 바로 발행하는 것이 아니라 OutboxEventPublisher를 사용하여 이벤트를 발행합니다. 

그리고 나중에 로그 트래킹을 위해 커스텀 TaskDecorator를 추가했습니다 (TaskLoggingDecorator) 왜냐하면 Outbox 이벤트는 비동기로 처리되기 때문에 로컬 스레드가 바뀌게 됩니다. 그렇게 되면 MDC 정보가 바뀌기 떄문에 트래킹에 불편함이 있을 수 있습니다. 그래서 이벤트를 이벤트를 처리하기 전에 사용하던 스레드의 MDC를 비동기 스레드로 복사하는 데코레이터를 추가했습니다.

이벤트를 발행하게 되면 MessageRelay를 통해 비동기로 이벤트가 처리되고 이때 스레드가 바뀌므로 에러가 

발행 할 이벤트 타입은 common/event/EventType.kt에 추가하여 범용적으로 사용할 수 있습니다. 

이벤트는 기본적으로 EventPayload를 상속받습니다. 
## ✅ 체크리스트
- [x] 코드 컨벤션을 지켰나요?
- [x] 테스트 케이스를 작성했나요?
- [x] 빌드가 정상적으로 됐나요?
- [x] 본인(작성자)를 assign 했나요?

## 🔗 관련 이슈
<!-- ex. Close #123 -->
Close #33

## 👀 리뷰어에게 바라는 점
<!-- 코드에서 중점적으로 봐줬으면 하는 부분이나, 궁금한 부분을 자유롭게 작성해주세요 -->
- 이벤트가 넣으려니까 어떤 레이어에 넣을지 감이 잘 안오는 것 같네요.. 패키징 구조 이상하면 의견 부탁드립니다.
- 문의사항 있으시면 언제든 말씀해주세요~
