### PR TITLE
[Refactor] 시큐리티 필터 체인 분리

### DIFF
--- a/.github/ISSUE_TEMPLATE/issue-form.yml
+++ b/.github/ISSUE_TEMPLATE/issue-form.yml
@@ -33,6 +33,7 @@ body:
         - refactor
         - chore
         - HOTFIX
+        - test
     validations:
       required: true
 

--- a/src/main/kotlin/com/yapp/brake/common/filter/JwtAuthenticationFilter.kt
+++ b/src/main/kotlin/com/yapp/brake/common/filter/JwtAuthenticationFilter.kt
@@ -18,14 +18,6 @@ class JwtAuthenticationFilter(
     private val jwtTokenProvider: JwtTokenProvider,
     private val blackListRepository: RedisBlackListRepository,
 ) : OncePerRequestFilter() {
-    override fun shouldNotFilter(request: HttpServletRequest): Boolean {
-        val path = request.servletPath
-        return path == "/health" ||
-            path.startsWith("/v1/auth/login") ||
-            path.startsWith("/static/swagger") ||
-            path.startsWith("/v1/swagger")
-    }
-
     override fun doFilterInternal(
         request: HttpServletRequest,
         response: HttpServletResponse,

--- a/src/main/kotlin/com/yapp/brake/common/filter/JwtAuthenticationFilter.kt
+++ b/src/main/kotlin/com/yapp/brake/common/filter/JwtAuthenticationFilter.kt
@@ -1,6 +1,6 @@
 package com.yapp.brake.common.filter
 
-import com.yapp.brake.auth.infrastructure.redis.RedisBlackListRepository
+import com.yapp.brake.auth.infrastructure.BlackListRepository
 import com.yapp.brake.auth.service.JwtTokenProvider
 import com.yapp.brake.common.constants.TOKEN_TYPE_ACCESS
 import com.yapp.brake.common.exception.CustomException
@@ -16,7 +16,7 @@ private val log = KotlinLogging.logger {}
 
 class JwtAuthenticationFilter(
     private val jwtTokenProvider: JwtTokenProvider,
-    private val blackListRepository: RedisBlackListRepository,
+    private val blackListRepository: BlackListRepository,
 ) : OncePerRequestFilter() {
     override fun doFilterInternal(
         request: HttpServletRequest,

--- a/src/main/kotlin/com/yapp/brake/common/security/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/yapp/brake/common/security/config/SecurityConfig.kt
@@ -1,6 +1,6 @@
 package com.yapp.brake.common.security.config
 
-import com.yapp.brake.auth.infrastructure.redis.RedisBlackListRepository
+import com.yapp.brake.auth.infrastructure.BlackListRepository
 import com.yapp.brake.auth.service.JwtTokenProvider
 import com.yapp.brake.common.filter.JwtAuthenticationFilter
 import com.yapp.brake.common.security.exception.ForbiddenHandler
@@ -22,8 +22,6 @@ class SecurityConfig(
     private val unauthenticatedEntryPoint: UnauthenticatedEntryPoint,
     private val forbiddenHandler: ForbiddenHandler,
     private val requestLoggingFilter: CommonsRequestLoggingFilter,
-    private val jwtTokenProvider: JwtTokenProvider,
-    private val blackListRepository: RedisBlackListRepository,
     private val corsConfigurationSource: CorsConfigurationSource,
 ) {
     @Bean
@@ -42,7 +40,11 @@ class SecurityConfig(
 
     @Bean
     @Order(2)
-    fun securityFilterChain(http: HttpSecurity): SecurityFilterChain {
+    fun securityFilterChain(
+        jwtTokenProvider: JwtTokenProvider,
+        blackListRepository: BlackListRepository,
+        http: HttpSecurity,
+    ): SecurityFilterChain {
         http
             .csrf { it.disable() }
             .sessionManagement {


### PR DESCRIPTION
## 🔍 반영 내용
<!-- 이번 PR에서 작업한 내용을 간단히 설명해주세요 -->
- 필터에서 관리하는 허용 URL을 시큐리티 설정에서 관리할 수 있도록 시큐리티 필터 체인을 분리했습니다.

## ✅ 체크리스트
- [x] 코드 컨벤션을 지켰나요?
- [ ] 테스트 케이스를 작성했나요?
- [x] 빌드가 정상적으로 됐나요?
- [x] 본인(작성자)를 assign 했나요?

## 🔗 관련 이슈
<!-- ex. Close #123 -->
Close #45 

## 👀 리뷰어에게 바라는 점
<!-- 코드에서 중점적으로 봐줬으면 하는 부분이나, 궁금한 부분을 자유롭게 작성해주세요 -->
- 문의사항 있으시면 말씀주십숑!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **문서**
  * 이슈 템플릿에 "test" 옵션이 추가되어 이슈 등록 시 선택할 수 있는 라벨이 확장되었습니다.

* **리팩터**
  * 보안 설정이 두 개의 필터 체인으로 분리되어, 허용된 URL과 그 외 요청에 대해 각각 별도의 보안 정책이 적용됩니다.
  * 블랙리스트 저장소 타입이 Redis 구현에서 더 일반적인 인터페이스로 변경되었습니다.
  * 인증 필터에서 특정 경로를 필터링에서 제외하는 로직이 제거되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->