### PR TITLE
[Feat] HOLD 상태 유저 필터 추가

### DIFF
--- a/src/main/kotlin/com/yapp/brake/auth/service/JwtTokenProvider.kt
+++ b/src/main/kotlin/com/yapp/brake/auth/service/JwtTokenProvider.kt
@@ -69,7 +69,10 @@ class JwtTokenProvider(
         return UsernamePasswordAuthenticationToken(
             member.id,
             null,
-            listOf(SimpleGrantedAuthority(member.role.toString())),
+            listOf(
+                SimpleGrantedAuthority(member.role.type),
+                SimpleGrantedAuthority(member.state.name),
+            ),
         )
     }
 

--- a/src/main/kotlin/com/yapp/brake/common/constants/GlobalConstants.kt
+++ b/src/main/kotlin/com/yapp/brake/common/constants/GlobalConstants.kt
@@ -2,4 +2,13 @@ package com.yapp.brake.common.constants
 
 const val TOKEN_TYPE_ACCESS = "access"
 const val TOKEN_TYPE_REFRESH = "refresh"
-val ALLOWED_URIS = listOf("/v1/auth/login", "/static/**", "/v1/swagger", "/actuator", "/actuator/**", "/static")
+val ALLOWED_URIS =
+    listOf(
+        "/v1/auth/login",
+        "/v1/auth/refresh",
+        "/static/**",
+        "/v1/swagger",
+        "/actuator",
+        "/actuator/**",
+        "/static",
+    )

--- a/src/main/kotlin/com/yapp/brake/common/filter/MemberStateFilter.kt
+++ b/src/main/kotlin/com/yapp/brake/common/filter/MemberStateFilter.kt
@@ -1,0 +1,42 @@
+package com.yapp.brake.common.filter
+
+import com.yapp.brake.member.model.MemberState
+import io.github.oshai.kotlinlogging.KotlinLogging
+import jakarta.servlet.FilterChain
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.security.access.AccessDeniedException
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.web.filter.OncePerRequestFilter
+
+private val log = KotlinLogging.logger {}
+
+class MemberStateFilter : OncePerRequestFilter() {
+    override fun shouldNotFilter(request: HttpServletRequest): Boolean {
+        return super.shouldNotFilter(request)
+    }
+
+    override fun doFilterInternal(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        filterChain: FilterChain,
+    ) {
+        val authorities =
+            SecurityContextHolder.getContext()
+                .authentication
+                .authorities
+
+        val memberState =
+            authorities
+                .map { it.authority }
+                .firstOrNull { it in MemberState.entries.map { e -> e.name } }
+                ?.let { MemberState.valueOf(it) }
+
+        if (memberState != MemberState.ACTIVE) {
+            log.error { "[MemberStateFilter.doFilterInternal] invalid memberState=$memberState" }
+            throw AccessDeniedException("")
+        }
+
+        filterChain.doFilter(request, response)
+    }
+}

--- a/src/test/kotlin/com/yapp/brake/auth/service/JwtTokenProviderTest.kt
+++ b/src/test/kotlin/com/yapp/brake/auth/service/JwtTokenProviderTest.kt
@@ -3,7 +3,6 @@ package com.yapp.brake.auth.service
 import com.yapp.brake.common.config.properties.JwtProperties
 import com.yapp.brake.common.constants.TOKEN_TYPE_ACCESS
 import com.yapp.brake.common.constants.TOKEN_TYPE_REFRESH
-import com.yapp.brake.common.enums.Role
 import com.yapp.brake.common.exception.CustomException
 import com.yapp.brake.common.exception.ErrorCode
 import com.yapp.brake.member.infrastructure.jpa.MemberJpaReader
@@ -97,7 +96,8 @@ class JwtTokenProviderTest {
 
         // then
         assertEquals(memberId, authentication.principal)
-        assertTrue(authentication.authorities.contains(SimpleGrantedAuthority(Role.USER.type)))
+        assertTrue(authentication.authorities.contains(SimpleGrantedAuthority(member.role.type)))
+        assertTrue(authentication.authorities.contains(SimpleGrantedAuthority(member.state.name)))
         assertEquals(null, authentication.credentials)
     }
 

--- a/src/test/kotlin/com/yapp/brake/auth/service/JwtTokenProviderTest.kt
+++ b/src/test/kotlin/com/yapp/brake/auth/service/JwtTokenProviderTest.kt
@@ -97,7 +97,7 @@ class JwtTokenProviderTest {
 
         // then
         assertEquals(memberId, authentication.principal)
-        assertTrue(authentication.authorities.contains(SimpleGrantedAuthority(Role.USER.name)))
+        assertTrue(authentication.authorities.contains(SimpleGrantedAuthority(Role.USER.type)))
         assertEquals(null, authentication.credentials)
     }
 


### PR DESCRIPTION
## 🔍 반영 내용
<!-- 이번 PR에서 작업한 내용을 간단히 설명해주세요 -->
HOLD 상태의 유저가 다른 API를 호출할 수 있어서 제한 하도록 필터 추가했습니다.

그리고 토큰 재발급은 인증 없이 가능하도록 첫번쨰 필터에 추가했어요. 만약에 만료된 액세스 토큰으로 리프레쉬 api를 호출하게 되면 실패하게 되네요

## ✅ 체크리스트
- [x] 코드 컨벤션을 지켰나요?
- [ ] 테스트 케이스를 작성했나요?
- [x] 빌드가 정상적으로 됐나요?
- [x] 본인(작성자)를 assign 했나요?

## 🔗 관련 이슈
<!-- ex. Close #123 -->
Close #62 

## 👀 리뷰어에게 바라는 점
<!-- 코드에서 중점적으로 봐줬으면 하는 부분이나, 궁금한 부분을 자유롭게 작성해주세요 -->
- 문의사항 있으시면 말씀 주셔용


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * 멤버 상태를 확인하여 비활성화된 멤버의 요청을 차단하는 필터가 추가되었습니다.

* **변경 사항**
  * JWT 인증 시 사용자 권한에 멤버 상태 정보가 추가되어 더욱 정교한 권한 관리가 가능해졌습니다.
  * 특정 API 요청에 대한 보안 필터 체인이 분리되어, 멤버 상태에 따라 접근 제어가 강화되었습니다.
  * 인증 관련 허용 URI에 "/v1/auth/refresh"가 추가되었습니다.

* **테스트**
  * 변경된 권한 구조에 맞춰 인증 관련 테스트가 수정되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->