### PR TITLE
[Fix] 디바이스 프로필을 구분 기준으로 변경

### DIFF
--- a/src/main/kotlin/com/yapp/brake/auth/controller/AuthController.kt
+++ b/src/main/kotlin/com/yapp/brake/auth/controller/AuthController.kt
@@ -7,6 +7,7 @@ import com.yapp.brake.auth.dto.response.OAuthLoginResponse
 import com.yapp.brake.auth.dto.response.RefreshTokenResponse
 import com.yapp.brake.auth.service.AuthUseCase
 import com.yapp.brake.common.dto.ApiResponse
+import com.yapp.brake.common.security.getDeviceProfileId
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.PostMapping
@@ -42,6 +43,6 @@ class AuthController(
         @RequestBody @Valid
         request: LogoutRequest,
     ) {
-        authUseCase.logout(request.accessToken)
+        authUseCase.logout(getDeviceProfileId(), request.accessToken)
     }
 }

--- a/src/main/kotlin/com/yapp/brake/auth/infrastructure/RefreshTokenRepository.kt
+++ b/src/main/kotlin/com/yapp/brake/auth/infrastructure/RefreshTokenRepository.kt
@@ -4,14 +4,14 @@ import java.time.Duration
 
 interface RefreshTokenRepository {
     fun add(
-        memberId: Long,
+        deviceProfileId: Long,
         token: String,
         ttl: Duration,
     )
 
-    fun read(memberId: Long): String?
+    fun read(deviceProfileId: Long): String?
 
-    fun get(memberId: Long): String
+    fun get(deviceProfileId: Long): String
 
-    fun remove(memberId: Long)
+    fun remove(deviceProfileId: Long)
 }

--- a/src/main/kotlin/com/yapp/brake/auth/infrastructure/redis/RedisRefreshTokenRepository.kt
+++ b/src/main/kotlin/com/yapp/brake/auth/infrastructure/redis/RedisRefreshTokenRepository.kt
@@ -15,33 +15,33 @@ class RedisRefreshTokenRepository(
     private val redisTemplate: StringRedisTemplate,
 ) : RefreshTokenRepository {
     override fun add(
-        memberId: Long,
+        deviceProfileId: Long,
         token: String,
         ttl: Duration,
     ) {
         try {
-            redisTemplate.opsForValue().set(generateKey(memberId), token, ttl)
+            redisTemplate.opsForValue().set(generateKey(deviceProfileId), token, ttl)
         } catch (e: Exception) {
-            logger.error(e) { "[RedisRefreshTokenRepository.add] memberId=$memberId, token=$token" }
+            logger.error(e) { "[RedisRefreshTokenRepository.add] deviceProfileId=$deviceProfileId, token=$token" }
             throw CustomException(ErrorCode.INTERNAL_SERVER_ERROR)
         }
     }
 
-    override fun read(memberId: Long): String? = redisTemplate.opsForValue().get(generateKey(memberId))
+    override fun read(deviceProfileId: Long): String? = redisTemplate.opsForValue().get(generateKey(deviceProfileId))
 
-    override fun get(memberId: Long): String =
+    override fun get(deviceProfileId: Long): String =
         redisTemplate.opsForValue()
-            .get(generateKey(memberId))
+            .get(generateKey(deviceProfileId))
             ?: throw CustomException(ErrorCode.TOKEN_NOT_FOUND)
 
-    override fun remove(memberId: Long) {
-        redisTemplate.delete(generateKey(memberId))
+    override fun remove(deviceProfileId: Long) {
+        redisTemplate.delete(generateKey(deviceProfileId))
     }
 
-    private fun generateKey(memberId: Long): String = KEY_FORMAT.format(memberId)
+    private fun generateKey(deviceProfileId: Long): String = KEY_FORMAT.format(deviceProfileId)
 
     companion object {
-        // auth::refresh-token::{memberId}
+        // auth::refresh-token::{deviceProfileId}
         private const val KEY_FORMAT = "auth::refresh-token::%s"
     }
 }

--- a/src/main/kotlin/com/yapp/brake/auth/service/AuthService.kt
+++ b/src/main/kotlin/com/yapp/brake/auth/service/AuthService.kt
@@ -10,7 +10,6 @@ import com.yapp.brake.common.enums.Role
 import com.yapp.brake.common.enums.SocialProvider
 import com.yapp.brake.common.exception.CustomException
 import com.yapp.brake.common.exception.ErrorCode
-import com.yapp.brake.common.security.getDeviceProfileId
 import com.yapp.brake.deviceprofile.infrastructure.DeviceProfileReader
 import com.yapp.brake.deviceprofile.infrastructure.DeviceProfileWriter
 import com.yapp.brake.deviceprofile.model.DeviceProfile
@@ -71,8 +70,11 @@ class AuthService(
         return RefreshTokenResponse(newAccessToken, newRefreshToken)
     }
 
-    override fun logout(accessToken: String) {
-        refreshTokenRepository.remove(getDeviceProfileId())
+    override fun logout(
+        deviceProfileId: Long,
+        accessToken: String,
+    ) {
+        refreshTokenRepository.remove(deviceProfileId)
 
         val ttl = jwtTokenProvider.extractExpiration(accessToken)
         blackListRepository.add(accessToken, Duration.ofMillis(ttl))

--- a/src/main/kotlin/com/yapp/brake/auth/service/AuthUseCase.kt
+++ b/src/main/kotlin/com/yapp/brake/auth/service/AuthUseCase.kt
@@ -9,5 +9,8 @@ interface AuthUseCase {
 
     fun refreshToken(refreshToken: String): RefreshTokenResponse
 
-    fun logout(accessToken: String)
+    fun logout(
+        deviceProfileId: Long,
+        accessToken: String,
+    )
 }

--- a/src/main/kotlin/com/yapp/brake/common/event/payload/MemberDeletedEventPayload.kt
+++ b/src/main/kotlin/com/yapp/brake/common/event/payload/MemberDeletedEventPayload.kt
@@ -7,5 +7,4 @@ data class MemberDeletedEventPayload(
     val socialProvider: String,
     val authId: String,
     val authEmail: String,
-    val deviceId: String,
 ) : EventPayload

--- a/src/main/kotlin/com/yapp/brake/common/event/payload/SessionAddedEventPayload.kt
+++ b/src/main/kotlin/com/yapp/brake/common/event/payload/SessionAddedEventPayload.kt
@@ -4,7 +4,7 @@ import com.yapp.brake.common.event.EventPayload
 import java.time.LocalDateTime
 
 data class SessionAddedEventPayload(
-    val memberId: Long,
+    val deviceProfileId: Long,
     val start: LocalDateTime,
     val end: LocalDateTime,
     val goalMinutes: Long,

--- a/src/main/kotlin/com/yapp/brake/common/exception/ErrorCode.kt
+++ b/src/main/kotlin/com/yapp/brake/common/exception/ErrorCode.kt
@@ -22,4 +22,8 @@ enum class ErrorCode(
 
     // Group
     GROUP_NOT_FOUND(404, "G-001", "관리 앱 그룹을 찾을 수 없습니다."),
+
+    // Device Profile
+    DEVICE_PROFILE_NOT_FOUND(404, "D-001", "디바이스 프로필을 찾을 수 없습니다."),
+    DEVICE_PROFILE_INVALID(400, "D-002", "디바이스 프로필 정보가 유효하지 않습니다."),
 }

--- a/src/main/kotlin/com/yapp/brake/common/filter/JwtAuthenticationFilter.kt
+++ b/src/main/kotlin/com/yapp/brake/common/filter/JwtAuthenticationFilter.kt
@@ -26,12 +26,13 @@ class JwtAuthenticationFilter(
         try {
             val accessToken = resolveToken(request)
             val memberId = jwtTokenProvider.extractMemberId(accessToken, TOKEN_TYPE_ACCESS)
+            val deviceProfileId = jwtTokenProvider.extractProfileId(accessToken)
 
             if (isBlackList(accessToken)) {
                 throw CustomException(ErrorCode.FORBIDDEN)
             }
 
-            val authentication = jwtTokenProvider.getAuthentication(memberId)
+            val authentication = jwtTokenProvider.getAuthentication(memberId, deviceProfileId)
 
             SecurityContextHolder.getContext().authentication = authentication
         } catch (e: Exception) {

--- a/src/main/kotlin/com/yapp/brake/common/security/SecurityUtils.kt
+++ b/src/main/kotlin/com/yapp/brake/common/security/SecurityUtils.kt
@@ -9,3 +9,10 @@ fun getMemberId(): Long =
         ?.name
         ?.toLongOrNull()
         ?: throw CustomException(ErrorCode.MEMBER_INVALID)
+
+fun getDeviceProfileId(): Long =
+    SecurityContextHolder.getContext().authentication
+        ?.credentials
+        ?.toString()
+        ?.toLongOrNull()
+        ?: throw CustomException(ErrorCode.DEVICE_PROFILE_INVALID)

--- a/src/main/kotlin/com/yapp/brake/deviceprofile/infrastructure/DeviceProfileReader.kt
+++ b/src/main/kotlin/com/yapp/brake/deviceprofile/infrastructure/DeviceProfileReader.kt
@@ -1,0 +1,12 @@
+package com.yapp.brake.deviceprofile.infrastructure
+
+import com.yapp.brake.deviceprofile.model.DeviceProfile
+
+interface DeviceProfileReader {
+    fun getById(deviceProfileId: Long): DeviceProfile
+
+    fun findByMemberIdAndDeviceName(
+        memberId: Long,
+        deviceName: String,
+    ): DeviceProfile?
+}

--- a/src/main/kotlin/com/yapp/brake/deviceprofile/infrastructure/DeviceProfileWriter.kt
+++ b/src/main/kotlin/com/yapp/brake/deviceprofile/infrastructure/DeviceProfileWriter.kt
@@ -1,0 +1,7 @@
+package com.yapp.brake.deviceprofile.infrastructure
+
+import com.yapp.brake.deviceprofile.model.DeviceProfile
+
+interface DeviceProfileWriter {
+    fun save(deviceProfile: DeviceProfile): DeviceProfile
+}

--- a/src/main/kotlin/com/yapp/brake/deviceprofile/infrastructure/DeviceProfileWriter.kt
+++ b/src/main/kotlin/com/yapp/brake/deviceprofile/infrastructure/DeviceProfileWriter.kt
@@ -4,4 +4,6 @@ import com.yapp.brake.deviceprofile.model.DeviceProfile
 
 interface DeviceProfileWriter {
     fun save(deviceProfile: DeviceProfile): DeviceProfile
+
+    fun deleteAllByMemberId(memberId: Long): Long
 }

--- a/src/main/kotlin/com/yapp/brake/deviceprofile/infrastructure/jpa/DeviceProfileEntity.kt
+++ b/src/main/kotlin/com/yapp/brake/deviceprofile/infrastructure/jpa/DeviceProfileEntity.kt
@@ -1,0 +1,37 @@
+package com.yapp.brake.deviceprofile.infrastructure.jpa
+
+import com.yapp.brake.common.persistence.Auditable
+import com.yapp.brake.deviceprofile.model.DeviceProfile
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+
+@Entity
+@Table(name = "device_profile")
+class DeviceProfileEntity(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val deviceProfileId: Long = 0L,
+    val deviceName: String,
+    val memberId: Long,
+) : Auditable() {
+    fun toDomain(): DeviceProfile {
+        return DeviceProfile(
+            id = deviceProfileId,
+            deviceName = deviceName,
+            memberId = memberId,
+        )
+    }
+
+    companion object {
+        fun create(deviceProfile: DeviceProfile): DeviceProfileEntity {
+            return DeviceProfileEntity(
+                deviceProfileId = deviceProfile.id,
+                deviceName = deviceProfile.deviceName,
+                memberId = deviceProfile.memberId,
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/yapp/brake/deviceprofile/infrastructure/jpa/DeviceProfileJpaReader.kt
+++ b/src/main/kotlin/com/yapp/brake/deviceprofile/infrastructure/jpa/DeviceProfileJpaReader.kt
@@ -1,0 +1,26 @@
+package com.yapp.brake.deviceprofile.infrastructure.jpa
+
+import com.yapp.brake.common.exception.CustomException
+import com.yapp.brake.common.exception.ErrorCode
+import com.yapp.brake.deviceprofile.infrastructure.DeviceProfileReader
+import com.yapp.brake.deviceprofile.model.DeviceProfile
+import org.springframework.stereotype.Repository
+import org.springframework.transaction.annotation.Transactional
+
+@Repository
+@Transactional(readOnly = true)
+class DeviceProfileJpaReader(
+    private val deviceProfileRepository: DeviceProfileRepository,
+) : DeviceProfileReader {
+    override fun getById(deviceProfileId: Long): DeviceProfile =
+        deviceProfileRepository.findById(deviceProfileId)
+            .orElseThrow { CustomException(ErrorCode.DEVICE_PROFILE_NOT_FOUND) }
+            .toDomain()
+
+    override fun findByMemberIdAndDeviceName(
+        memberId: Long,
+        deviceName: String,
+    ): DeviceProfile? =
+        deviceProfileRepository.findByMemberIdAndDeviceName(memberId, deviceName)
+            ?.toDomain()
+}

--- a/src/main/kotlin/com/yapp/brake/deviceprofile/infrastructure/jpa/DeviceProfileJpaWriter.kt
+++ b/src/main/kotlin/com/yapp/brake/deviceprofile/infrastructure/jpa/DeviceProfileJpaWriter.kt
@@ -1,0 +1,17 @@
+package com.yapp.brake.deviceprofile.infrastructure.jpa
+
+import com.yapp.brake.deviceprofile.infrastructure.DeviceProfileWriter
+import com.yapp.brake.deviceprofile.model.DeviceProfile
+import org.springframework.stereotype.Repository
+import org.springframework.transaction.annotation.Transactional
+
+@Repository
+@Transactional
+class DeviceProfileJpaWriter(
+    private val deviceProfileRepository: DeviceProfileRepository,
+) : DeviceProfileWriter {
+    override fun save(deviceProfile: DeviceProfile): DeviceProfile {
+        val entity = DeviceProfileEntity.create(deviceProfile)
+        return deviceProfileRepository.save(entity).toDomain()
+    }
+}

--- a/src/main/kotlin/com/yapp/brake/deviceprofile/infrastructure/jpa/DeviceProfileJpaWriter.kt
+++ b/src/main/kotlin/com/yapp/brake/deviceprofile/infrastructure/jpa/DeviceProfileJpaWriter.kt
@@ -14,4 +14,8 @@ class DeviceProfileJpaWriter(
         val entity = DeviceProfileEntity.create(deviceProfile)
         return deviceProfileRepository.save(entity).toDomain()
     }
+
+    override fun deleteAllByMemberId(memberId: Long): Long {
+        return deviceProfileRepository.deleteAllByMemberId(memberId)
+    }
 }

--- a/src/main/kotlin/com/yapp/brake/deviceprofile/infrastructure/jpa/DeviceProfileRepository.kt
+++ b/src/main/kotlin/com/yapp/brake/deviceprofile/infrastructure/jpa/DeviceProfileRepository.kt
@@ -1,0 +1,10 @@
+package com.yapp.brake.deviceprofile.infrastructure.jpa
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface DeviceProfileRepository : JpaRepository<DeviceProfileEntity, Long> {
+    fun findByMemberIdAndDeviceName(
+        memberId: Long,
+        deviceName: String,
+    ): DeviceProfileEntity?
+}

--- a/src/main/kotlin/com/yapp/brake/deviceprofile/infrastructure/jpa/DeviceProfileRepository.kt
+++ b/src/main/kotlin/com/yapp/brake/deviceprofile/infrastructure/jpa/DeviceProfileRepository.kt
@@ -7,4 +7,6 @@ interface DeviceProfileRepository : JpaRepository<DeviceProfileEntity, Long> {
         memberId: Long,
         deviceName: String,
     ): DeviceProfileEntity?
+
+    fun deleteAllByMemberId(memberId: Long): Long
 }

--- a/src/main/kotlin/com/yapp/brake/deviceprofile/model/DeviceProfile.kt
+++ b/src/main/kotlin/com/yapp/brake/deviceprofile/model/DeviceProfile.kt
@@ -1,0 +1,19 @@
+package com.yapp.brake.deviceprofile.model
+
+data class DeviceProfile(
+    val id: Long = 0L,
+    val memberId: Long,
+    val deviceName: String,
+) {
+    companion object {
+        fun create(
+            memberId: Long,
+            deviceName: String,
+        ): DeviceProfile {
+            return DeviceProfile(
+                memberId = memberId,
+                deviceName = deviceName,
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/yapp/brake/deviceprofile/service/eventhandler/DeviceProfileDeletedEventHandler.kt
+++ b/src/main/kotlin/com/yapp/brake/deviceprofile/service/eventhandler/DeviceProfileDeletedEventHandler.kt
@@ -1,0 +1,18 @@
+package com.yapp.brake.deviceprofile.service.eventhandler
+
+import com.yapp.brake.common.event.EventHandler
+import com.yapp.brake.common.event.EventType
+import com.yapp.brake.common.event.payload.MemberDeletedEventPayload
+import com.yapp.brake.deviceprofile.infrastructure.DeviceProfileWriter
+import org.springframework.stereotype.Component
+
+@Component
+class DeviceProfileDeletedEventHandler(
+    private val deviceProfileWriter: DeviceProfileWriter,
+) : EventHandler<MemberDeletedEventPayload> {
+    override val eventType: EventType = EventType.MEMBER_DELETED
+
+    override fun handle(payload: MemberDeletedEventPayload) {
+        deviceProfileWriter.deleteAllByMemberId(payload.memberId)
+    }
+}

--- a/src/main/kotlin/com/yapp/brake/group/controller/GroupController.kt
+++ b/src/main/kotlin/com/yapp/brake/group/controller/GroupController.kt
@@ -1,7 +1,7 @@
 package com.yapp.brake.group.controller
 
 import com.yapp.brake.common.dto.ApiResponse
-import com.yapp.brake.common.security.getMemberId
+import com.yapp.brake.common.security.getDeviceProfileId
 import com.yapp.brake.group.dto.request.CreateGroupRequest
 import com.yapp.brake.group.dto.request.UpdateGroupRequest
 import com.yapp.brake.group.dto.response.GroupResponse
@@ -32,12 +32,12 @@ class GroupController(
     ): ApiResponse<GroupResponse> {
         return ApiResponse.success(
             code = HttpStatus.CREATED.value(),
-            data = groupUseCase.create(getMemberId(), request),
+            data = groupUseCase.create(getDeviceProfileId(), request),
         )
     }
 
     @GetMapping
-    fun readAll(): ApiResponse<GroupsResponse> = ApiResponse.success(groupUseCase.getAll(getMemberId()))
+    fun readAll(): ApiResponse<GroupsResponse> = ApiResponse.success(groupUseCase.getAll(getDeviceProfileId()))
 
     @PutMapping("/{groupId}")
     fun modify(
@@ -46,7 +46,7 @@ class GroupController(
         @Valid @RequestBody
         request: UpdateGroupRequest,
     ): ApiResponse<GroupResponse> {
-        return ApiResponse.success(groupUseCase.modify(getMemberId(), groupId, request))
+        return ApiResponse.success(groupUseCase.modify(getDeviceProfileId(), groupId, request))
     }
 
     @DeleteMapping("/{groupId}")
@@ -55,6 +55,6 @@ class GroupController(
         @PathVariable @Positive
         groupId: Long,
     ) {
-        groupUseCase.remove(getMemberId(), groupId)
+        groupUseCase.remove(getDeviceProfileId(), groupId)
     }
 }

--- a/src/main/kotlin/com/yapp/brake/group/infrastructure/jpa/GroupEntity.kt
+++ b/src/main/kotlin/com/yapp/brake/group/infrastructure/jpa/GroupEntity.kt
@@ -14,13 +14,13 @@ class GroupEntity(
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     val groupId: Long = 0L,
-    val memberId: Long,
+    val deviceProfileId: Long,
     val name: String,
 ) : Auditable() {
     fun toDomain() =
         Group(
             groupId = groupId,
-            memberId = memberId,
+            deviceProfileId = deviceProfileId,
             name = name,
             createdAt = createdAt,
             updatedAt = updatedAt,
@@ -30,7 +30,7 @@ class GroupEntity(
         fun from(group: Group) =
             GroupEntity(
                 groupId = group.groupId,
-                memberId = group.memberId,
+                deviceProfileId = group.deviceProfileId,
                 name = group.name,
             )
     }

--- a/src/main/kotlin/com/yapp/brake/group/infrastructure/jpa/GroupJpaReader.kt
+++ b/src/main/kotlin/com/yapp/brake/group/infrastructure/jpa/GroupJpaReader.kt
@@ -16,12 +16,12 @@ class GroupJpaReader(
         groupId: Long,
         memberId: Long,
     ): Group {
-        return groupRepository.findByGroupIdAndMemberId(groupId, memberId)
+        return groupRepository.findByGroupIdAndDeviceProfileId(groupId, memberId)
             ?.toDomain()
             ?: throw CustomException(ErrorCode.GROUP_NOT_FOUND)
     }
 
     override fun getAllByMemberId(memberId: Long): List<Group> =
-        groupRepository.findByMemberId(memberId)
+        groupRepository.findByDeviceProfileId(memberId)
             .map(GroupEntity::toDomain)
 }

--- a/src/main/kotlin/com/yapp/brake/group/infrastructure/jpa/GroupRepository.kt
+++ b/src/main/kotlin/com/yapp/brake/group/infrastructure/jpa/GroupRepository.kt
@@ -3,10 +3,10 @@ package com.yapp.brake.group.infrastructure.jpa
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface GroupRepository : JpaRepository<GroupEntity, Long> {
-    fun findByGroupIdAndMemberId(
+    fun findByGroupIdAndDeviceProfileId(
         groupId: Long,
-        memberId: Long,
+        deviceProfileId: Long,
     ): GroupEntity?
 
-    fun findByMemberId(memberId: Long): List<GroupEntity>
+    fun findByDeviceProfileId(deviceProfileId: Long): List<GroupEntity>
 }

--- a/src/main/kotlin/com/yapp/brake/group/model/Group.kt
+++ b/src/main/kotlin/com/yapp/brake/group/model/Group.kt
@@ -5,7 +5,7 @@ import java.time.LocalDateTime
 data class Group(
     val groupId: Long,
     val name: String,
-    val memberId: Long,
+    val deviceProfileId: Long,
     val createdAt: LocalDateTime? = null,
     var updatedAt: LocalDateTime? = null,
 ) {
@@ -16,12 +16,12 @@ data class Group(
 
     companion object {
         fun create(
-            memberId: Long,
+            deviceProfileId: Long,
             name: String,
         ) = Group(
             groupId = 0L,
             name = name,
-            memberId = memberId,
+            deviceProfileId = deviceProfileId,
         )
     }
 }

--- a/src/main/kotlin/com/yapp/brake/group/service/GroupService.kt
+++ b/src/main/kotlin/com/yapp/brake/group/service/GroupService.kt
@@ -27,10 +27,10 @@ class GroupService(
 ) : GroupUseCase {
     @Transactional
     override fun create(
-        memberId: Long,
+        deviceProfileId: Long,
         request: CreateGroupRequest,
     ): GroupResponse {
-        val group = groupWriter.save(Group.create(memberId, request.name))
+        val group = groupWriter.save(Group.create(deviceProfileId, request.name))
         val groupApps =
             request.groupApps.map {
                 val groupApp =
@@ -46,8 +46,8 @@ class GroupService(
     }
 
     @Transactional(readOnly = true)
-    override fun getAll(memberId: Long): GroupsResponse {
-        val groups = groupReader.getAllByMemberId(memberId)
+    override fun getAll(deviceProfileId: Long): GroupsResponse {
+        val groups = groupReader.getAllByMemberId(deviceProfileId)
         val groupIds = groups.map(Group::groupId)
         val groupApps = groupAppReader.getByGroupIds(groupIds)
 
@@ -56,12 +56,12 @@ class GroupService(
 
     @Transactional
     override fun modify(
-        memberId: Long,
+        deviceProfileId: Long,
         groupId: Long,
         request: UpdateGroupRequest,
     ): GroupResponse {
         val group =
-            groupReader.getByIdAndMemberId(groupId, memberId)
+            groupReader.getByIdAndMemberId(groupId, deviceProfileId)
                 .update(request.name)
                 .let { groupWriter.save(it) }
 
@@ -84,10 +84,10 @@ class GroupService(
 
     @Transactional
     override fun remove(
-        memberId: Long,
+        deviceProfileId: Long,
         groupId: Long,
     ) {
-        val group = groupReader.getByIdAndMemberId(groupId, memberId)
+        val group = groupReader.getByIdAndMemberId(groupId, deviceProfileId)
 
         groupWriter.delete(group)
 

--- a/src/main/kotlin/com/yapp/brake/group/service/GroupUseCase.kt
+++ b/src/main/kotlin/com/yapp/brake/group/service/GroupUseCase.kt
@@ -7,20 +7,20 @@ import com.yapp.brake.group.dto.response.GroupsResponse
 
 interface GroupUseCase {
     fun create(
-        memberId: Long,
+        deviceProfileId: Long,
         request: CreateGroupRequest,
     ): GroupResponse
 
-    fun getAll(memberId: Long): GroupsResponse
+    fun getAll(deviceProfileId: Long): GroupsResponse
 
     fun modify(
-        memberId: Long,
+        deviceProfileId: Long,
         groupId: Long,
         request: UpdateGroupRequest,
     ): GroupResponse
 
     fun remove(
-        memberId: Long,
+        deviceProfileId: Long,
         groupId: Long,
     )
 }

--- a/src/main/kotlin/com/yapp/brake/member/controller/MemberController.kt
+++ b/src/main/kotlin/com/yapp/brake/member/controller/MemberController.kt
@@ -27,7 +27,7 @@ class MemberController(
     fun update(
         @Valid @RequestBody
         request: UpdateNicknameRequest,
-    ): ApiResponse<MemberResponse> = ApiResponse.success(memberUseCase.update(request.nickname))
+    ): ApiResponse<MemberResponse> = ApiResponse.success(memberUseCase.update(getMemberId(), request.nickname))
 
     @DeleteMapping("/me")
     @ResponseStatus(HttpStatus.NO_CONTENT)

--- a/src/main/kotlin/com/yapp/brake/member/infrastructure/MemberReader.kt
+++ b/src/main/kotlin/com/yapp/brake/member/infrastructure/MemberReader.kt
@@ -1,9 +1,13 @@
 package com.yapp.brake.member.infrastructure
 
+import com.yapp.brake.common.enums.SocialProvider
 import com.yapp.brake.member.model.Member
 
 interface MemberReader {
-    fun findByDeviceId(deviceId: String): Member?
+    fun findByOauthInfo(
+        email: String,
+        socialProvider: SocialProvider,
+    ): Member?
 
     fun findById(memberId: Long): Member?
 

--- a/src/main/kotlin/com/yapp/brake/member/infrastructure/jpa/MemberEntity.kt
+++ b/src/main/kotlin/com/yapp/brake/member/infrastructure/jpa/MemberEntity.kt
@@ -20,7 +20,6 @@ class MemberEntity(
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     val memberId: Long = 0L,
-    val deviceId: String,
     val credential: String,
     val authEmail: String,
     @Enumerated(EnumType.STRING)
@@ -45,7 +44,6 @@ class MemberEntity(
     fun toDomain() =
         Member(
             id = memberId,
-            deviceId = deviceId,
             oAuthUserInfo = OAuthUserInfo(socialProvider, credential, authEmail),
             nickname = nickname,
             role = role,
@@ -58,7 +56,6 @@ class MemberEntity(
         fun create(member: Member) =
             MemberEntity(
                 memberId = member.id,
-                deviceId = member.deviceId,
                 credential = member.oAuthUserInfo.credential,
                 authEmail = member.oAuthUserInfo.email,
                 nickname = member.nickname,

--- a/src/main/kotlin/com/yapp/brake/member/infrastructure/jpa/MemberJpaReader.kt
+++ b/src/main/kotlin/com/yapp/brake/member/infrastructure/jpa/MemberJpaReader.kt
@@ -1,5 +1,6 @@
 package com.yapp.brake.member.infrastructure.jpa
 
+import com.yapp.brake.common.enums.SocialProvider
 import com.yapp.brake.common.exception.CustomException
 import com.yapp.brake.common.exception.ErrorCode
 import com.yapp.brake.member.infrastructure.MemberReader
@@ -13,8 +14,11 @@ import kotlin.jvm.optionals.getOrNull
 class MemberJpaReader(
     private val memberRepository: MemberRepository,
 ) : MemberReader {
-    override fun findByDeviceId(deviceId: String): Member? =
-        memberRepository.findByDeviceId(deviceId)
+    override fun findByOauthInfo(
+        email: String,
+        socialProvider: SocialProvider,
+    ): Member? =
+        memberRepository.findByAuthEmailAndSocialProvider(email, socialProvider)
             ?.toDomain()
 
     override fun findById(memberId: Long): Member? =

--- a/src/main/kotlin/com/yapp/brake/member/infrastructure/jpa/MemberRepository.kt
+++ b/src/main/kotlin/com/yapp/brake/member/infrastructure/jpa/MemberRepository.kt
@@ -1,7 +1,11 @@
 package com.yapp.brake.member.infrastructure.jpa
 
+import com.yapp.brake.common.enums.SocialProvider
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface MemberRepository : JpaRepository<MemberEntity, Long> {
-    fun findByDeviceId(deviceId: String): MemberEntity?
+    fun findByAuthEmailAndSocialProvider(
+        authEmail: String,
+        socialProvider: SocialProvider,
+    ): MemberEntity?
 }

--- a/src/main/kotlin/com/yapp/brake/member/model/Member.kt
+++ b/src/main/kotlin/com/yapp/brake/member/model/Member.kt
@@ -8,7 +8,6 @@ data class Member(
     val id: Long = 0L,
     var nickname: String? = null,
     val oAuthUserInfo: OAuthUserInfo,
-    val deviceId: String,
     val role: Role,
     var state: MemberState,
     val createdAt: LocalDateTime? = null,
@@ -24,11 +23,9 @@ data class Member(
 
     companion object {
         fun create(
-            deviceId: String,
             oAuthUserInfo: OAuthUserInfo,
             role: Role,
         ) = Member(
-            deviceId = deviceId,
             oAuthUserInfo = oAuthUserInfo,
             role = role,
             state = MemberState.HOLD,

--- a/src/main/kotlin/com/yapp/brake/member/service/MemberService.kt
+++ b/src/main/kotlin/com/yapp/brake/member/service/MemberService.kt
@@ -35,7 +35,6 @@ class MemberService(
     override fun delete(memberId: Long) {
         val member = memberReader.getById(memberId)
         memberWriter.delete(memberId)
-        // todo : 회원 탈퇴 시 회원의 디바이스 프로필도 삭제해야 함
 
         val payload =
             MemberDeletedEventPayload(

--- a/src/main/kotlin/com/yapp/brake/member/service/MemberService.kt
+++ b/src/main/kotlin/com/yapp/brake/member/service/MemberService.kt
@@ -2,7 +2,6 @@ package com.yapp.brake.member.service
 
 import com.yapp.brake.common.event.EventType
 import com.yapp.brake.common.event.payload.MemberDeletedEventPayload
-import com.yapp.brake.common.security.getMemberId
 import com.yapp.brake.member.dto.response.MemberResponse
 import com.yapp.brake.member.infrastructure.MemberReader
 import com.yapp.brake.member.infrastructure.MemberWriter
@@ -21,9 +20,12 @@ class MemberService(
     override fun getMember(memberId: Long): MemberResponse = MemberResponse.from(memberReader.getById(memberId))
 
     @Transactional
-    override fun update(nickname: String): MemberResponse {
+    override fun update(
+        memberId: Long,
+        nickname: String,
+    ): MemberResponse {
         val member =
-            memberReader.getById(getMemberId())
+            memberReader.getById(memberId)
                 .update(nickname, MemberState.ACTIVE)
 
         return MemberResponse.from(memberWriter.save(member))
@@ -33,6 +35,7 @@ class MemberService(
     override fun delete(memberId: Long) {
         val member = memberReader.getById(memberId)
         memberWriter.delete(memberId)
+        // todo : 회원 탈퇴 시 회원의 디바이스 프로필도 삭제해야 함
 
         val payload =
             MemberDeletedEventPayload(
@@ -40,7 +43,6 @@ class MemberService(
                 socialProvider = member.oAuthUserInfo.socialProvider.name,
                 authId = member.oAuthUserInfo.credential,
                 authEmail = member.oAuthUserInfo.email,
-                deviceId = member.deviceId,
             )
 
         outboxEventPublisher.publish(EventType.MEMBER_DELETED, payload)

--- a/src/main/kotlin/com/yapp/brake/member/service/MemberUseCase.kt
+++ b/src/main/kotlin/com/yapp/brake/member/service/MemberUseCase.kt
@@ -5,7 +5,10 @@ import com.yapp.brake.member.dto.response.MemberResponse
 interface MemberUseCase {
     fun getMember(memberId: Long): MemberResponse
 
-    fun update(nickname: String): MemberResponse
+    fun update(
+        memberId: Long,
+        nickname: String,
+    ): MemberResponse
 
     fun delete(memberId: Long)
 }

--- a/src/main/kotlin/com/yapp/brake/session/controller/SessionController.kt
+++ b/src/main/kotlin/com/yapp/brake/session/controller/SessionController.kt
@@ -1,7 +1,7 @@
 package com.yapp.brake.session.controller
 
 import com.yapp.brake.common.dto.ApiResponse
-import com.yapp.brake.common.security.getMemberId
+import com.yapp.brake.common.security.getDeviceProfileId
 import com.yapp.brake.session.dto.request.AddSessionRequest
 import com.yapp.brake.session.dto.response.AddSessionResponse
 import com.yapp.brake.session.service.SessionUseCase
@@ -22,7 +22,7 @@ class SessionController(
         @Valid @RequestBody
         request: AddSessionRequest,
     ): ApiResponse<AddSessionResponse> {
-        val response = sessionUseCase.add(getMemberId(), request)
+        val response = sessionUseCase.add(getDeviceProfileId(), request)
 
         return ApiResponse.success(
             code = HttpStatus.CREATED.value(),

--- a/src/main/kotlin/com/yapp/brake/session/infrastructure/jpa/SessionEntity.kt
+++ b/src/main/kotlin/com/yapp/brake/session/infrastructure/jpa/SessionEntity.kt
@@ -16,7 +16,7 @@ class SessionEntity(
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     val sessionId: Long = 0L,
     val groupId: Long,
-    val memberId: Long,
+    val deviceProfileId: Long,
     val start: LocalDateTime,
     val end: LocalDateTime,
     val goalMinutes: Long,
@@ -27,7 +27,7 @@ class SessionEntity(
         Session(
             id = sessionId,
             groupId = groupId,
-            memberId = memberId,
+            deviceProfileId = deviceProfileId,
             start = start,
             end = end,
             goalMinutes = goalMinutes,
@@ -43,7 +43,7 @@ class SessionEntity(
             SessionEntity(
                 sessionId = session.id,
                 groupId = session.groupId,
-                memberId = session.memberId,
+                deviceProfileId = session.deviceProfileId,
                 start = session.start,
                 end = session.end,
                 goalMinutes = session.goalMinutes,

--- a/src/main/kotlin/com/yapp/brake/session/model/Session.kt
+++ b/src/main/kotlin/com/yapp/brake/session/model/Session.kt
@@ -5,7 +5,7 @@ import java.time.LocalDateTime
 data class Session(
     val id: Long = 0L,
     val groupId: Long,
-    val memberId: Long,
+    val deviceProfileId: Long,
     val start: LocalDateTime,
     val end: LocalDateTime,
     val goalMinutes: Long,
@@ -21,7 +21,7 @@ data class Session(
             snoozeUnit: Int,
             snoozeCount: Int,
         ) = Session(
-            memberId = memberId,
+            deviceProfileId = memberId,
             groupId = groupId,
             start = start,
             end = end,

--- a/src/main/kotlin/com/yapp/brake/session/service/SessionService.kt
+++ b/src/main/kotlin/com/yapp/brake/session/service/SessionService.kt
@@ -17,12 +17,12 @@ class SessionService(
 ) : SessionUseCase {
     @Transactional
     override fun add(
-        memberId: Long,
+        deviceProfileId: Long,
         request: AddSessionRequest,
     ): AddSessionResponse {
         val session =
             Session.create(
-                memberId,
+                deviceProfileId,
                 request.groupId,
                 request.start,
                 request.end,
@@ -34,7 +34,7 @@ class SessionService(
 
         val payload =
             SessionAddedEventPayload(
-                memberId = memberId,
+                deviceProfileId = deviceProfileId,
                 start = session.start,
                 end = session.end,
                 goalMinutes = request.goalMinutes,

--- a/src/main/kotlin/com/yapp/brake/session/service/SessionUseCase.kt
+++ b/src/main/kotlin/com/yapp/brake/session/service/SessionUseCase.kt
@@ -5,7 +5,7 @@ import com.yapp.brake.session.dto.response.AddSessionResponse
 
 interface SessionUseCase {
     fun add(
-        memberId: Long,
+        deviceProfileId: Long,
         request: AddSessionRequest,
     ): AddSessionResponse
 }

--- a/src/main/kotlin/com/yapp/brake/statistic/controller/StatisticController.kt
+++ b/src/main/kotlin/com/yapp/brake/statistic/controller/StatisticController.kt
@@ -1,7 +1,7 @@
 package com.yapp.brake.statistic.controller
 
 import com.yapp.brake.common.dto.ApiResponse
-import com.yapp.brake.common.security.getMemberId
+import com.yapp.brake.common.security.getDeviceProfileId
 import com.yapp.brake.statistic.dto.request.QueryStatisticRequest
 import com.yapp.brake.statistic.dto.response.SessionStatisticsResponse
 import com.yapp.brake.statistic.service.StatisticUseCase
@@ -21,7 +21,8 @@ class StatisticController(
         @Valid @ModelAttribute
         request: QueryStatisticRequest,
     ): ApiResponse<SessionStatisticsResponse> {
-        val response = statisticUseCase.get(getMemberId(), request.getStartOrDefault(), request.getEndOrDefault())
+        val response =
+            statisticUseCase.get(getDeviceProfileId(), request.getStartOrDefault(), request.getEndOrDefault())
         return ApiResponse.success(response)
     }
 }

--- a/src/main/kotlin/com/yapp/brake/statistic/infrastructure/DailySessionStatisticReader.kt
+++ b/src/main/kotlin/com/yapp/brake/statistic/infrastructure/DailySessionStatisticReader.kt
@@ -6,12 +6,12 @@ import java.time.LocalDate
 
 interface DailySessionStatisticReader {
     fun getById(
-        memberId: Long,
+        deviceProfileId: Long,
         date: LocalDate,
     ): DailySessionStatistic
 
     fun getAllByIds(
-        memberId: Long,
+        deviceProfileId: Long,
         dates: List<LocalDate>,
     ): SessionStatistics
 }

--- a/src/main/kotlin/com/yapp/brake/statistic/infrastructure/jpa/DailySessionStatisticEntity.kt
+++ b/src/main/kotlin/com/yapp/brake/statistic/infrastructure/jpa/DailySessionStatisticEntity.kt
@@ -13,7 +13,7 @@ import java.time.LocalDate
 @Table(name = "daily_session_statistic")
 class DailySessionStatisticEntity(
     @Id
-    val memberId: Long,
+    val deviceProfileId: Long,
     @Id
     val date: LocalDate,
     val actualMinutes: Long,
@@ -22,7 +22,7 @@ class DailySessionStatisticEntity(
     companion object {
         fun create(dailySessionStatistic: DailySessionStatistic): DailySessionStatisticEntity {
             return DailySessionStatisticEntity(
-                memberId = dailySessionStatistic.memberId,
+                deviceProfileId = dailySessionStatistic.deviceProfileId,
                 date = dailySessionStatistic.date,
                 actualMinutes = dailySessionStatistic.actualMinutes,
                 goalMinutes = dailySessionStatistic.goalMinutes,
@@ -32,7 +32,7 @@ class DailySessionStatisticEntity(
         fun create(sessionStatistics: SessionStatistics): List<DailySessionStatisticEntity> {
             return sessionStatistics.statistics.map {
                 DailySessionStatisticEntity(
-                    memberId = it.memberId,
+                    deviceProfileId = it.deviceProfileId,
                     date = it.date,
                     actualMinutes = it.actualMinutes,
                     goalMinutes = it.goalMinutes,
@@ -43,7 +43,7 @@ class DailySessionStatisticEntity(
 
     fun toDomain(): DailySessionStatistic {
         return DailySessionStatistic(
-            memberId = memberId,
+            deviceProfileId = deviceProfileId,
             date = date,
             actualMinutes = actualMinutes,
             goalMinutes = goalMinutes,

--- a/src/main/kotlin/com/yapp/brake/statistic/infrastructure/jpa/DailySessionStatisticId.kt
+++ b/src/main/kotlin/com/yapp/brake/statistic/infrastructure/jpa/DailySessionStatisticId.kt
@@ -4,6 +4,6 @@ import java.io.Serializable
 import java.time.LocalDate
 
 data class DailySessionStatisticId(
-    var memberId: Long = 0L,
+    var deviceProfileId: Long = 0L,
     var date: LocalDate = LocalDate.MIN,
 ) : Serializable

--- a/src/main/kotlin/com/yapp/brake/statistic/infrastructure/jpa/DailySessionStatisticJpaReader.kt
+++ b/src/main/kotlin/com/yapp/brake/statistic/infrastructure/jpa/DailySessionStatisticJpaReader.kt
@@ -14,20 +14,20 @@ class DailySessionStatisticJpaReader(
     private val dailySessionStatisticRepository: DailySessionStatisticRepository,
 ) : DailySessionStatisticReader {
     override fun getById(
-        memberId: Long,
+        deviceProfileId: Long,
         date: LocalDate,
     ): DailySessionStatistic {
-        return dailySessionStatisticRepository.findById(DailySessionStatisticId(memberId, date))
+        return dailySessionStatisticRepository.findById(DailySessionStatisticId(deviceProfileId, date))
             .getOrNull()
             ?.toDomain()
-            ?: DailySessionStatistic(memberId, date)
+            ?: DailySessionStatistic(deviceProfileId, date)
     }
 
     override fun getAllByIds(
-        memberId: Long,
+        deviceProfileId: Long,
         dates: List<LocalDate>,
     ): SessionStatistics {
-        val ids = dates.map { DailySessionStatisticId(memberId, it) }
+        val ids = dates.map { DailySessionStatisticId(deviceProfileId, it) }
         val statistics = dailySessionStatisticRepository.findAllById(ids).map { it.toDomain() }
         return SessionStatistics(statistics)
     }

--- a/src/main/kotlin/com/yapp/brake/statistic/model/DailySessionStatistic.kt
+++ b/src/main/kotlin/com/yapp/brake/statistic/model/DailySessionStatistic.kt
@@ -3,19 +3,19 @@ package com.yapp.brake.statistic.model
 import java.time.LocalDate
 
 data class DailySessionStatistic(
-    val memberId: Long,
+    val deviceProfileId: Long,
     val date: LocalDate,
     val actualMinutes: Long = 0L,
     val goalMinutes: Long = 0L,
 ) {
-    fun add(memberUsage: MemberUsage): DailySessionStatistic {
-        if (memberUsage.start.toLocalDate() != date) {
+    fun add(deviceUsage: DeviceUsage): DailySessionStatistic {
+        if (deviceUsage.start.toLocalDate() != date) {
             return this
         }
 
         return copy(
-            actualMinutes = actualMinutes + memberUsage.toActualMinutes(),
-            goalMinutes = goalMinutes + memberUsage.goalMinutes,
+            actualMinutes = actualMinutes + deviceUsage.toActualMinutes(),
+            goalMinutes = goalMinutes + deviceUsage.goalMinutes,
         )
     }
 }

--- a/src/main/kotlin/com/yapp/brake/statistic/model/DeviceUsage.kt
+++ b/src/main/kotlin/com/yapp/brake/statistic/model/DeviceUsage.kt
@@ -3,8 +3,8 @@ package com.yapp.brake.statistic.model
 import java.time.Duration
 import java.time.LocalDateTime
 
-data class MemberUsage(
-    val memberId: Long,
+data class DeviceUsage(
+    val deviceProfileId: Long,
     val start: LocalDateTime,
     val end: LocalDateTime,
     val goalMinutes: Long,
@@ -13,7 +13,7 @@ data class MemberUsage(
         return Duration.between(start, end).toMinutes()
     }
 
-    fun splitByDate(): List<MemberUsage> {
+    fun splitByDate(): List<DeviceUsage> {
         val startDate = start.toLocalDate()
         val endDate = end.toLocalDate()
 

--- a/src/main/kotlin/com/yapp/brake/statistic/model/SessionStatistics.kt
+++ b/src/main/kotlin/com/yapp/brake/statistic/model/SessionStatistics.kt
@@ -3,16 +3,16 @@ package com.yapp.brake.statistic.model
 data class SessionStatistics(
     val statistics: List<DailySessionStatistic>,
 ) {
-    fun update(memberUsage: MemberUsage): SessionStatistics {
+    fun update(deviceUsage: DeviceUsage): SessionStatistics {
         val updatedMap = statistics.associateBy { it.date }.toMutableMap()
 
-        for (dailyUsage in memberUsage.splitByDate()) {
+        for (dailyUsage in deviceUsage.splitByDate()) {
             val date = dailyUsage.start.toLocalDate()
             val dailySessionStatistic =
                 updatedMap[date]
                     ?: DailySessionStatistic(
                         date = date,
-                        memberId = dailyUsage.memberId,
+                        deviceProfileId = dailyUsage.deviceProfileId,
                     )
             updatedMap[date] = dailySessionStatistic.add(dailyUsage)
         }

--- a/src/main/kotlin/com/yapp/brake/statistic/service/StatisticService.kt
+++ b/src/main/kotlin/com/yapp/brake/statistic/service/StatisticService.kt
@@ -13,12 +13,12 @@ class StatisticService(
 ) : StatisticUseCase {
     @Transactional(readOnly = true)
     override fun get(
-        memberId: Long,
+        deviceProfileId: Long,
         startDate: LocalDate,
         endDate: LocalDate,
     ): SessionStatisticsResponse {
         val betweenDates = generateBetweenDates(startDate, endDate)
-        val statistics = dailySessionStatisticReader.getAllByIds(memberId, betweenDates)
+        val statistics = dailySessionStatisticReader.getAllByIds(deviceProfileId, betweenDates)
 
         return SessionStatisticsResponse.from(statistics)
     }

--- a/src/main/kotlin/com/yapp/brake/statistic/service/StatisticUseCase.kt
+++ b/src/main/kotlin/com/yapp/brake/statistic/service/StatisticUseCase.kt
@@ -5,7 +5,7 @@ import java.time.LocalDate
 
 interface StatisticUseCase {
     fun get(
-        memberId: Long,
+        deviceProfileId: Long,
         startDate: LocalDate,
         endDate: LocalDate,
     ): SessionStatisticsResponse

--- a/src/main/kotlin/com/yapp/brake/statistic/service/eventhandler/StatisticsUpdatedEventHandler.kt
+++ b/src/main/kotlin/com/yapp/brake/statistic/service/eventhandler/StatisticsUpdatedEventHandler.kt
@@ -6,7 +6,7 @@ import com.yapp.brake.common.event.payload.SessionAddedEventPayload
 import com.yapp.brake.session.utils.generateBetweenDates
 import com.yapp.brake.statistic.infrastructure.DailySessionStatisticReader
 import com.yapp.brake.statistic.infrastructure.DailySessionStatisticWriter
-import com.yapp.brake.statistic.model.MemberUsage
+import com.yapp.brake.statistic.model.DeviceUsage
 import org.springframework.stereotype.Component
 
 @Component
@@ -17,16 +17,16 @@ class StatisticsUpdatedEventHandler(
     override val eventType: EventType = EventType.SESSION_ADDED
 
     override fun handle(payload: SessionAddedEventPayload) {
-        val memberUsage =
-            MemberUsage(
-                memberId = payload.memberId,
+        val deviceUsage =
+            DeviceUsage(
+                deviceProfileId = payload.deviceProfileId,
                 start = payload.start,
                 end = payload.end,
                 goalMinutes = payload.goalMinutes,
             )
-        val betweenDates = generateBetweenDates(memberUsage.start, memberUsage.end)
-        val statistics = dailySessionStatisticReader.getAllByIds(memberUsage.memberId, betweenDates)
-        val updated = statistics.update(memberUsage)
+        val betweenDates = generateBetweenDates(deviceUsage.start, deviceUsage.end)
+        val statistics = dailySessionStatisticReader.getAllByIds(deviceUsage.deviceProfileId, betweenDates)
+        val updated = statistics.update(deviceUsage)
         dailySessionStatisticWriter.saveAll(updated)
     }
 }

--- a/src/main/resources/db/migration/V20250726.101__create_device_profile.sql
+++ b/src/main/resources/db/migration/V20250726.101__create_device_profile.sql
@@ -1,0 +1,29 @@
+CREATE TABLE device_profile
+(
+    device_profile_id bigint       NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    member_id         bigint       NOT NULL,
+    device_name       VARCHAR(255) NOT NULL,
+    created_at        datetime     NULL,
+    updated_at        datetime     NULL
+);
+
+ALTER TABLE `member`
+    DROP INDEX uk_member_device_id;
+
+ALTER TABLE `member`
+    DROP COLUMN device_id;
+
+ALTER TABLE `member`
+    ADD UNIQUE KEY uk_member_auth_email_social_provider (auth_email, social_provider);
+
+DROP INDEX idx_session_member_id ON session;
+DROP INDEX idx_group_member_id ON `group`;
+
+ALTER TABLE session
+    CHANGE COLUMN member_id device_profile_id bigint NOT NULL;
+
+ALTER TABLE `group`
+    CHANGE COLUMN member_id device_profile_id bigint NOT NULL;
+
+ALTER TABLE daily_session_statistic
+    CHANGE COLUMN member_id device_profile_id bigint NOT NULL;

--- a/src/test/kotlin/com/yapp/brake/auth/controller/AuthControllerTest.kt
+++ b/src/test/kotlin/com/yapp/brake/auth/controller/AuthControllerTest.kt
@@ -21,6 +21,8 @@ import org.mockito.kotlin.doNothing
 import org.mockito.kotlin.whenever
 import org.springframework.http.MediaType
 import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import java.util.UUID
 
@@ -105,9 +107,14 @@ class AuthControllerTest : RestApiTestBase() {
 
     @Test
     fun `로그아웃 API`() {
+        val memberId = 1L
+        val deviceProfileId = 1L
         val request = LogoutRequest("accessToken")
 
-        doNothing().whenever(authUseCase).logout(request.accessToken)
+        val authentication = UsernamePasswordAuthenticationToken(memberId, deviceProfileId)
+        SecurityContextHolder.getContext().authentication = authentication
+
+        doNothing().whenever(authUseCase).logout(deviceProfileId, request.accessToken)
 
         val builder =
             RestDocumentationRequestBuilders.post("/v1/auth/logout")

--- a/src/test/kotlin/com/yapp/brake/auth/service/AuthServiceTest.kt
+++ b/src/test/kotlin/com/yapp/brake/auth/service/AuthServiceTest.kt
@@ -177,7 +177,7 @@ class AuthServiceTest {
 
         whenever(jwtTokenProvider.extractExpiration(accessToken)).thenReturn(ttl)
         // when
-        authService.logout(accessToken)
+        authService.logout(deviceProfileId, accessToken)
 
         // then
         verify(refreshTokenRepository).remove(memberId)

--- a/src/test/kotlin/com/yapp/brake/common/event/EventTest.kt
+++ b/src/test/kotlin/com/yapp/brake/common/event/EventTest.kt
@@ -4,7 +4,6 @@ import com.yapp.brake.common.enums.SocialProvider
 import com.yapp.brake.common.event.payload.MemberDeletedEventPayload
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
-import java.util.UUID
 
 class EventTest {
     @Test
@@ -15,7 +14,6 @@ class EventTest {
                 socialProvider = SocialProvider.KAKAO.name,
                 authId = "123124",
                 authEmail = "auth@kakao.com",
-                deviceId = UUID.randomUUID().toString(),
             )
 
         val event = Event.of(EventType.MEMBER_DELETED, payload)

--- a/src/test/kotlin/com/yapp/brake/group/controller/GroupControllerTest.kt
+++ b/src/test/kotlin/com/yapp/brake/group/controller/GroupControllerTest.kt
@@ -30,6 +30,7 @@ class GroupControllerTest : RestApiTestBase() {
     @Test
     fun `관리 앱 그룹 생성 API`() {
         val memberId = 1L
+        val deviceProfileId = 1L
         val request = createGroupRequestFixture()
         val response =
             ApiResponse.success(
@@ -40,7 +41,7 @@ class GroupControllerTest : RestApiTestBase() {
         whenever(groupUseCase.create(memberId, request))
             .thenReturn(response.data)
 
-        val authentication = UsernamePasswordAuthenticationToken(memberId.toString(), null)
+        val authentication = UsernamePasswordAuthenticationToken(memberId.toString(), deviceProfileId)
         SecurityContextHolder.getContext().authentication = authentication
 
         val builder =
@@ -76,6 +77,7 @@ class GroupControllerTest : RestApiTestBase() {
     @Test
     fun `관리 앱 그룹 조회 API`() {
         val memberId = 1L
+        val deviceProfileId = 1L
         val response =
             ApiResponse.success(
                 code = HttpStatus.OK.value(),
@@ -85,7 +87,7 @@ class GroupControllerTest : RestApiTestBase() {
         whenever(groupUseCase.getAll(memberId))
             .thenReturn(response.data)
 
-        val authentication = UsernamePasswordAuthenticationToken(memberId.toString(), null)
+        val authentication = UsernamePasswordAuthenticationToken(memberId.toString(), deviceProfileId)
         SecurityContextHolder.getContext().authentication = authentication
 
         val builder =
@@ -114,6 +116,7 @@ class GroupControllerTest : RestApiTestBase() {
     @Test
     fun `관리 앱 그룹 수정 API`() {
         val memberId = 1L
+        val deviceProfileId = 1L
         val groupId = 1L
         val request =
             updateGroupRequestFixture(
@@ -134,7 +137,7 @@ class GroupControllerTest : RestApiTestBase() {
         whenever(groupUseCase.modify(memberId, groupId, request))
             .thenReturn(response.data)
 
-        val authentication = UsernamePasswordAuthenticationToken(memberId.toString(), null)
+        val authentication = UsernamePasswordAuthenticationToken(memberId.toString(), deviceProfileId)
         SecurityContextHolder.getContext().authentication = authentication
 
         val builder =
@@ -173,10 +176,11 @@ class GroupControllerTest : RestApiTestBase() {
     fun `관리 앱 그룹 삭제 API`() {
         val memberId = 1L
         val groupId = 1L
+        val deviceProfileId = 1L
 
         doNothing().whenever(groupUseCase).remove(memberId, groupId)
 
-        val authentication = UsernamePasswordAuthenticationToken(memberId.toString(), null)
+        val authentication = UsernamePasswordAuthenticationToken(memberId.toString(), deviceProfileId)
         SecurityContextHolder.getContext().authentication = authentication
 
         val builder = RestDocumentationRequestBuilders.delete("/v1/groups/{groupId}", groupId)

--- a/src/test/kotlin/com/yapp/brake/group/service/GroupServiceTest.kt
+++ b/src/test/kotlin/com/yapp/brake/group/service/GroupServiceTest.kt
@@ -55,7 +55,7 @@ class GroupServiceTest {
             groupApps.first { it.name == arg.name }
         }
 
-        val result = groupService.create(group.memberId, request)
+        val result = groupService.create(group.deviceProfileId, request)
 
         assertThat(result.groupId).isEqualTo(group.groupId)
         assertThat(result.name).isEqualTo(group.name)
@@ -113,16 +113,16 @@ class GroupServiceTest {
                     )
                 }
 
-            whenever(groupReader.getByIdAndMemberId(group.groupId, group.memberId)).thenReturn(group)
+            whenever(groupReader.getByIdAndMemberId(group.groupId, group.deviceProfileId)).thenReturn(group)
             whenever(groupWriter.save(any())).thenReturn(updatedGroup)
             whenever(groupAppReader.getByGroupId(group.groupId)).thenReturn(groupApps)
 
-            val result = groupService.modify(group.memberId, group.groupId, request)
+            val result = groupService.modify(group.deviceProfileId, group.groupId, request)
 
             assertThat(result.groupId).isEqualTo(group.groupId)
             assertThat(result.name).isEqualTo(group.name)
 
-            verify(groupReader).getByIdAndMemberId(group.groupId, group.memberId)
+            verify(groupReader).getByIdAndMemberId(group.groupId, group.deviceProfileId)
             verify(groupWriter).save(any())
             verify(outboxEventPublisher, never()).publish(any(), any())
         }
@@ -157,7 +157,7 @@ class GroupServiceTest {
                     )
                 }
 
-            whenever(groupReader.getByIdAndMemberId(group.groupId, group.memberId)).thenReturn(group)
+            whenever(groupReader.getByIdAndMemberId(group.groupId, group.deviceProfileId)).thenReturn(group)
             whenever(groupWriter.save(any())).thenReturn(updatedGroup)
             whenever(groupAppReader.getByGroupId(group.groupId)).thenReturn(originGroupApps)
             whenever(groupAppWriter.save(any())).thenAnswer { invocation ->
@@ -165,14 +165,14 @@ class GroupServiceTest {
                 updatedGroupApps.first { it.name == arg.name }
             }
 
-            val result = groupService.modify(group.memberId, group.groupId, request)
+            val result = groupService.modify(group.deviceProfileId, group.groupId, request)
 
             assertThat(result.groupId).isEqualTo(group.groupId)
             assertThat(result.name).isEqualTo(group.name)
             assertThat(result.groupApps).hasSize(request.groupApps.size)
 
             verify(groupAppWriter, times(2)).save(any())
-            verify(groupReader).getByIdAndMemberId(group.groupId, group.memberId)
+            verify(groupReader).getByIdAndMemberId(group.groupId, group.deviceProfileId)
             verify(groupWriter).save(any())
             verify(outboxEventPublisher).publish(any(), any())
         }
@@ -205,12 +205,12 @@ class GroupServiceTest {
         fun `관리 그룹을 삭제한다`() {
             val group = groupFixture(groupId = 1L)
 
-            whenever(groupReader.getByIdAndMemberId(group.groupId, group.memberId)).thenReturn(group)
+            whenever(groupReader.getByIdAndMemberId(group.groupId, group.deviceProfileId)).thenReturn(group)
             doNothing().whenever(outboxEventPublisher).publish(any(), any())
 
-            groupService.remove(group.memberId, group.groupId)
+            groupService.remove(group.deviceProfileId, group.groupId)
 
-            verify(groupReader).getByIdAndMemberId(group.groupId, group.memberId)
+            verify(groupReader).getByIdAndMemberId(group.groupId, group.deviceProfileId)
             verify(groupWriter).delete(group)
             verify(outboxEventPublisher).publish(any(), any())
         }

--- a/src/test/kotlin/com/yapp/brake/member/controller/MemberControllerTest.kt
+++ b/src/test/kotlin/com/yapp/brake/member/controller/MemberControllerTest.kt
@@ -59,6 +59,7 @@ class MemberControllerTest : RestApiTestBase() {
 
     @Test
     fun `내정보 수정 API`() {
+        val memberId = 1L
         val request =
             UpdateNicknameRequest(
                 nickname = "열글자이내닉네임",
@@ -71,7 +72,10 @@ class MemberControllerTest : RestApiTestBase() {
                 ),
             )
 
-        whenever(memberUseCase.update(request.nickname)).thenReturn(response.data)
+        val authentication = UsernamePasswordAuthenticationToken(memberId.toString(), null)
+        SecurityContextHolder.getContext().authentication = authentication
+
+        whenever(memberUseCase.update(memberId, request.nickname)).thenReturn(response.data)
 
         val builder =
             RestDocumentationRequestBuilders.patch("/v1/members/me")

--- a/src/test/kotlin/com/yapp/brake/member/service/MemberServiceTest.kt
+++ b/src/test/kotlin/com/yapp/brake/member/service/MemberServiceTest.kt
@@ -67,7 +67,7 @@ class MemberServiceTest {
         whenever(memberReader.getById(memberId = member.id)).thenReturn(member)
         whenever(memberWriter.save(any())).thenReturn(expected)
 
-        val result = memberService.update(newNickname)
+        val result = memberService.update(member.id, newNickname)
 
         assertThat(result.nickname).isEqualTo(expected.nickname)
         assertThat(result.state).isEqualTo(MemberState.ACTIVE.name)
@@ -84,7 +84,6 @@ class MemberServiceTest {
                 socialProvider = member.oAuthUserInfo.socialProvider.name,
                 authId = member.oAuthUserInfo.credential,
                 authEmail = member.oAuthUserInfo.email,
-                deviceId = member.deviceId,
             )
         whenever(memberReader.getById(memberId = member.id)).thenReturn(member)
         doNothing().whenever(memberWriter).delete(member.id)

--- a/src/test/kotlin/com/yapp/brake/session/controller/SessionControllerTest.kt
+++ b/src/test/kotlin/com/yapp/brake/session/controller/SessionControllerTest.kt
@@ -26,6 +26,7 @@ class SessionControllerTest : RestApiTestBase() {
     @Test
     fun `세션 추가 API`() {
         val memberId = 1L
+        val deviceProfileId = 1L
         val session = sessionFixture()
         val request =
             AddSessionRequest(
@@ -43,7 +44,7 @@ class SessionControllerTest : RestApiTestBase() {
                 data = AddSessionResponse(sessionId = 1L),
             )
 
-        val authentication = UsernamePasswordAuthenticationToken(memberId.toString(), null)
+        val authentication = UsernamePasswordAuthenticationToken(memberId.toString(), deviceProfileId)
         SecurityContextHolder.getContext().authentication = authentication
 
         whenever(

--- a/src/test/kotlin/com/yapp/brake/session/service/SessionServiceTest.kt
+++ b/src/test/kotlin/com/yapp/brake/session/service/SessionServiceTest.kt
@@ -32,7 +32,7 @@ class SessionServiceTest {
 
         // when
         sessionService.add(
-            session.memberId,
+            session.deviceProfileId,
             request,
         )
 

--- a/src/test/kotlin/com/yapp/brake/statistic/controller/StatisticControllerTest.kt
+++ b/src/test/kotlin/com/yapp/brake/statistic/controller/StatisticControllerTest.kt
@@ -28,6 +28,7 @@ import java.time.LocalTime
 
 class StatisticControllerTest : RestApiTestBase() {
     val memberId = 1L
+    val deviceProfileId = 1L
     val start = LocalDate.of(2025, 7, 17)
     val end = LocalDate.of(2025, 7, 18)
     val response =
@@ -58,7 +59,7 @@ class StatisticControllerTest : RestApiTestBase() {
 
     @Test
     fun `앱 사용 통계 조회 API`() {
-        val authentication = UsernamePasswordAuthenticationToken(memberId.toString(), null)
+        val authentication = UsernamePasswordAuthenticationToken(memberId.toString(), deviceProfileId)
         SecurityContextHolder.getContext().authentication = authentication
 
         whenever(statisticUseCase.get(memberId, start, end)).thenReturn(response.data)
@@ -72,6 +73,7 @@ class StatisticControllerTest : RestApiTestBase() {
             .andExpect(status().isOk)
             .andDocument("statistic-get") {
                 tag(Tag.STATISTIC)
+                responseSchema(response.data!!::class.java.simpleName)
                 queryParameters(
                     "start" means "통계 조회 시작일" optional true,
                     "end" means "통계 조회 종료일" optional true,
@@ -90,7 +92,7 @@ class StatisticControllerTest : RestApiTestBase() {
 
     @Test
     fun `앱 사용 통계 조회 API - 파라미터 X`() {
-        val authentication = UsernamePasswordAuthenticationToken(memberId.toString(), null)
+        val authentication = UsernamePasswordAuthenticationToken(memberId.toString(), deviceProfileId)
         SecurityContextHolder.getContext().authentication = authentication
 
         whenever(
@@ -111,7 +113,7 @@ class StatisticControllerTest : RestApiTestBase() {
     @ParameterizedTest
     @ValueSource(strings = ["start", "end"])
     fun `앱 사용 통계 조회 API - 파라미터 일부`(date: String) {
-        val authentication = UsernamePasswordAuthenticationToken(memberId.toString(), null)
+        val authentication = UsernamePasswordAuthenticationToken(memberId.toString(), deviceProfileId)
         SecurityContextHolder.getContext().authentication = authentication
 
         whenever(

--- a/src/test/kotlin/com/yapp/brake/statistic/infrastructure/jpa/statistics/DailySessionStatisticJpaReaderTest.kt
+++ b/src/test/kotlin/com/yapp/brake/statistic/infrastructure/jpa/statistics/DailySessionStatisticJpaReaderTest.kt
@@ -40,7 +40,7 @@ class DailySessionStatisticJpaReaderTest {
         val entity =
             DailySessionStatisticEntity(
                 date = date,
-                memberId = memberId,
+                deviceProfileId = memberId,
                 actualMinutes = 25L,
                 goalMinutes = 30L,
             )

--- a/src/test/kotlin/com/yapp/brake/statistic/model/DailySessionStatisticTest.kt
+++ b/src/test/kotlin/com/yapp/brake/statistic/model/DailySessionStatisticTest.kt
@@ -39,7 +39,7 @@ class DailySessionStatisticTest {
         assertAll(
             { assertEquals(originStatistics.actualMinutes + usageMinutes, updated.actualMinutes) },
             { assertEquals(originStatistics.goalMinutes + goalMinutes, updated.goalMinutes) },
-            { assertEquals(memberId, updated.memberId) },
+            { assertEquals(memberId, updated.deviceProfileId) },
             { assertEquals(date, updated.date) },
         )
     }
@@ -70,7 +70,7 @@ class DailySessionStatisticTest {
         assertAll(
             { assertEquals(originStatistics.actualMinutes + usageMinutes, updated.actualMinutes) },
             { assertEquals(originStatistics.goalMinutes + goalMinutes, updated.goalMinutes) },
-            { assertEquals(memberId, updated.memberId) },
+            { assertEquals(memberId, updated.deviceProfileId) },
             { assertEquals(date, updated.date) },
         )
     }
@@ -100,7 +100,7 @@ class DailySessionStatisticTest {
         assertAll(
             { assertEquals(originStatistics.actualMinutes, updated.actualMinutes) },
             { assertEquals(originStatistics.goalMinutes, updated.goalMinutes) },
-            { assertEquals(memberId, updated.memberId) },
+            { assertEquals(memberId, updated.deviceProfileId) },
             { assertEquals(date, updated.date) },
         )
     }

--- a/src/test/kotlin/com/yapp/brake/statistic/model/DeviceUsageTest.kt
+++ b/src/test/kotlin/com/yapp/brake/statistic/model/DeviceUsageTest.kt
@@ -7,7 +7,7 @@ import java.time.LocalDate
 import java.time.LocalDateTime
 import kotlin.test.assertEquals
 
-class MemberUsageTest {
+class DeviceUsageTest {
     @Test
     fun `실제 사용 시간을 계산한다`() {
         // given

--- a/src/test/kotlin/com/yapp/brake/statistic/service/eventhandler/StatisticsUpdatedEventHandlerTest.kt
+++ b/src/test/kotlin/com/yapp/brake/statistic/service/eventhandler/StatisticsUpdatedEventHandlerTest.kt
@@ -21,7 +21,7 @@ class StatisticsUpdatedEventHandlerTest {
     val session = sessionFixture()
     val payload =
         SessionAddedEventPayload(
-            memberId = session.memberId,
+            deviceProfileId = session.deviceProfileId,
             start = session.start,
             end = session.end,
             goalMinutes = session.goalMinutes,

--- a/src/test/kotlin/com/yapp/brake/support/fixture/event/EventPayloadFixture.kt
+++ b/src/test/kotlin/com/yapp/brake/support/fixture/event/EventPayloadFixture.kt
@@ -5,7 +5,6 @@ import com.yapp.brake.common.event.payload.MemberDeletedEventPayload
 import com.yapp.brake.outbox.model.Outbox
 import com.yapp.brake.outbox.model.OutboxEvent
 import com.yapp.brake.support.fixture.model.outboxFixture
-import java.util.UUID
 
 fun outboxEventPayloadFixture(outbox: Outbox = outboxFixture()) =
     OutboxEvent(
@@ -17,11 +16,9 @@ fun memberDeletedEventPayloadFixture(
     socialProvider: String = SocialProvider.KAKAO.name,
     authId: String = "1231023",
     authEmail: String = "auth@email.com",
-    deviceId: String = UUID.randomUUID().toString(),
 ) = MemberDeletedEventPayload(
     memberId = memberId,
     socialProvider = socialProvider,
     authId = authId,
     authEmail = authEmail,
-    deviceId = deviceId,
 )

--- a/src/test/kotlin/com/yapp/brake/support/fixture/model/DeviceProfileFixture.kt
+++ b/src/test/kotlin/com/yapp/brake/support/fixture/model/DeviceProfileFixture.kt
@@ -1,0 +1,13 @@
+package com.yapp.brake.support.fixture.model
+
+import com.yapp.brake.deviceprofile.model.DeviceProfile
+
+fun deviceProfileFixture(
+    id: Long = 1L,
+    memberId: Long = 1L,
+    deviceName: String = "Test Device",
+) = DeviceProfile(
+    id = id,
+    memberId = memberId,
+    deviceName = deviceName,
+)

--- a/src/test/kotlin/com/yapp/brake/support/fixture/model/GroupFixture.kt
+++ b/src/test/kotlin/com/yapp/brake/support/fixture/model/GroupFixture.kt
@@ -11,7 +11,7 @@ fun groupFixture(
     updatedAt: LocalDateTime? = null,
 ) = Group(
     groupId = groupId,
-    memberId = memberId,
+    deviceProfileId = memberId,
     name = name,
     createdAt = createdAt,
     updatedAt = updatedAt,

--- a/src/test/kotlin/com/yapp/brake/support/fixture/model/MemberFixture.kt
+++ b/src/test/kotlin/com/yapp/brake/support/fixture/model/MemberFixture.kt
@@ -6,13 +6,11 @@ import com.yapp.brake.member.model.Member
 import com.yapp.brake.member.model.MemberState
 import com.yapp.brake.oauth.model.OAuthUserInfo
 import java.time.LocalDateTime
-import java.util.UUID
 
 fun memberFixture(
     id: Long = 0L,
     nickname: String? = null,
     oAuthUserInfo: OAuthUserInfo = OAuthUserInfo(SocialProvider.KAKAO, "11111", "brake@kakao.com"),
-    deviceId: String = UUID.randomUUID().toString(),
     role: Role = Role.USER,
     state: MemberState = MemberState.ACTIVE,
     createdAt: LocalDateTime? = null,
@@ -21,7 +19,6 @@ fun memberFixture(
     id = id,
     nickname = nickname,
     oAuthUserInfo = oAuthUserInfo,
-    deviceId = deviceId,
     role = role,
     state = state,
     createdAt = createdAt,

--- a/src/test/kotlin/com/yapp/brake/support/fixture/model/SessionFixture.kt
+++ b/src/test/kotlin/com/yapp/brake/support/fixture/model/SessionFixture.kt
@@ -15,7 +15,7 @@ fun sessionFixture(
     snoozeCount: Int = 0,
 ) = Session(
     id = sessionId,
-    memberId = memberId,
+    deviceProfileId = memberId,
     groupId = groupId,
     start = start,
     end = end,

--- a/src/test/kotlin/com/yapp/brake/support/fixture/model/UsedInfoFixture.kt
+++ b/src/test/kotlin/com/yapp/brake/support/fixture/model/UsedInfoFixture.kt
@@ -1,6 +1,6 @@
 package com.yapp.brake.support.fixture.model
 
-import com.yapp.brake.statistic.model.MemberUsage
+import com.yapp.brake.statistic.model.DeviceUsage
 import java.time.LocalDateTime
 
 fun memberUsageFixture(
@@ -8,8 +8,8 @@ fun memberUsageFixture(
     start: LocalDateTime = LocalDateTime.of(2025, 7, 18, 0, 0, 0),
     end: LocalDateTime = start.plusMinutes(30),
     goalMinutes: Long = 30L,
-) = MemberUsage(
-    memberId = memberId,
+) = DeviceUsage(
+    deviceProfileId = memberId,
     start = start,
     end = end,
     goalMinutes = goalMinutes,


### PR DESCRIPTION
## 🔍 반영 내용
- member를 참조하던 그룹, 세션, 통계 도메인을 deviceProfile을 참조하도록 변경했습니다.
- member 탈퇴 시 member에 관련된 deviceProfile을 모두 삭제하는 이벤트를 발행합니다.
- 로그아웃은 기기별로 따로 관리하기에 refreshToken의 redis key를 deviceProfileId로 변경했습니다.
- 전체적으로 Controller에서 SecurityUtils를 사용하도록 변경했습니다.

## ✅ 체크리스트
- [x] 코드 컨벤션을 지켰나요?
- [x] 테스트 케이스를 작성했나요?
- [x] 빌드가 정상적으로 됐나요?
- [x] 본인(작성자)를 assign 했나요?

## 🔗 관련 이슈
<!-- ex. Close #123 -->
Close #67 

## 👀 리뷰어에게 바라는 점
<!-- 코드에서 중점적으로 봐줬으면 하는 부분이나, 궁금한 부분을 자유롭게 작성해주세요 -->
- member, deviceProfile을 기준으로 사용자를 구분하는 부분에서 기획과 다른 부분이 있는지 자세히 봐주시면 감사하겠습니다 🙇‍♀️
