### PR TITLE
[Feat] 카카오, 애플 에러코드 구체화

### DIFF
--- a/src/main/kotlin/com/yapp/brake/common/exception/ErrorCode.kt
+++ b/src/main/kotlin/com/yapp/brake/common/exception/ErrorCode.kt
@@ -27,4 +27,10 @@ enum class ErrorCode(
     // Device Profile
     DEVICE_PROFILE_NOT_FOUND(404, "D-001", "디바이스 프로필을 찾을 수 없습니다."),
     DEVICE_PROFILE_INVALID(400, "D-002", "디바이스 프로필 정보가 유효하지 않습니다."),
+
+    // OAuth
+    OAUTH_APPLE_AUTH_INVALID(400, "O-001", "유효하지 않은 애플 인증 정보입니다."),
+    OAUTH_APPLE_API_SERVER_ERROR(500, "O-002", "애플 로그인 처리 중 내부 오류가 발생했습니다."),
+    OAUTH_KAKAO_AUTH_INVALID(400, "O-003", "유효하지 않은 카카오 인증 정보입니다."),
+    OAUTH_KAKAO_API_SERVER_ERROR(500, "O-004", "카카오 로그인 처리 중 내부 오류가 발생했습니다."),
 }


### PR DESCRIPTION
## 🔍 반영 내용
<!-- 이번 PR에서 작업한 내용을 간단히 설명해주세요 -->
애플, 카카오 에러 시 클라로 부터 받은 값에 의한 에러인지 서버 에러인지 구분이 모호해서 구체화했습니다.
## ✅ 체크리스트
- [x] 코드 컨벤션을 지켰나요?
- [ ] 테스트 케이스를 작성했나요?
- [x] 빌드가 정상적으로 됐나요?
- [x] 본인(작성자)를 assign 했나요?

## 🔗 관련 이슈
<!-- ex. Close #123 -->
Close #78 

## 👀 리뷰어에게 바라는 점
<!-- 코드에서 중점적으로 봐줬으면 하는 부분이나, 궁금한 부분을 자유롭게 작성해주세요 -->
- 애플은 아래 링크보고 참고했는데 이상한 점 있으면 말씀해주세요!
https://developer.apple.com/documentation/signinwithapplerestapi/generate_and_validate_tokens


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * Apple 및 Kakao 로그인 과정에서 인증 오류와 서버 오류를 보다 명확하게 구분하여 안내 메시지가 개선되었습니다.
  * Apple 로그인 시 인증 정보가 유효하지 않거나 내부 서버 오류가 발생할 경우 각각 다른 오류 메시지가 제공됩니다.
  * Kakao 로그인 시 인증 오류와 서버 오류를 구분하여 보다 정확한 오류 안내가 제공됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->